### PR TITLE
[codex] Add six digit identifiers

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -70,6 +70,100 @@ function isAdminRole(role) {
     return String(role || '').toLowerCase() === 'admin';
 }
 
+function normalizeSixDigitIdentifier(value) {
+    const identifier = String(value || '').trim();
+    return /^\d{6}$/.test(identifier) ? identifier : null;
+}
+
+function generateSixDigitIdentifier() {
+    return String(Math.floor(Math.random() * 1000000)).padStart(6, '0');
+}
+
+function isAlreadyExistsError(error) {
+    const code = error && error.code;
+    const message = String((error && error.message) || '');
+    return code === 6 || code === 'already-exists' || message.includes('ALREADY_EXISTS');
+}
+
+async function reserveUniqueIdentifier(ownerType, ownerId) {
+    const registry = db.collection('identifierRegistry');
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+        const identifier = generateSixDigitIdentifier();
+        try {
+            await registry.doc(identifier).create({
+                identifier,
+                ownerType,
+                ownerId,
+                createdAt: FieldValue.serverTimestamp(),
+            });
+            return identifier;
+        } catch (error) {
+            if (isAlreadyExistsError(error)) continue;
+            throw error;
+        }
+    }
+    throw new Error('Could not allocate a unique identifier. Please try again.');
+}
+
+async function reserveExistingIdentifier(identifier, ownerType, ownerId) {
+    try {
+        await db.collection('identifierRegistry').doc(identifier).create({
+            identifier,
+            ownerType,
+            ownerId,
+            createdAt: FieldValue.serverTimestamp(),
+        });
+    } catch (error) {
+        if (!isAlreadyExistsError(error)) throw error;
+    }
+}
+
+async function ensureDocumentIdentifier(ref, data, ownerType, ownerId) {
+    const existing = normalizeSixDigitIdentifier(data && data.identifier);
+    if (existing) {
+        await reserveExistingIdentifier(existing, ownerType, ownerId);
+        return existing;
+    }
+
+    const identifier = await reserveUniqueIdentifier(ownerType, ownerId);
+    await ref.set({ identifier }, { merge: true });
+    return identifier;
+}
+
+async function ensureUserIdentifier(userId) {
+    if (!userId) return null;
+    const ref = db.collection('users').doc(userId);
+    const doc = await ref.get();
+    return ensureDocumentIdentifier(ref, doc.exists ? doc.data() : {}, 'user', userId);
+}
+
+async function ensureBrigadeIdentifier(brigadeId, ref, data) {
+    if (!brigadeId) return null;
+    const brigadeRef = ref || db.collection('brigades').doc(brigadeId);
+    let brigadeData = data;
+    if (!brigadeData) {
+        const doc = await brigadeRef.get();
+        brigadeData = doc.exists ? doc.data() : {};
+    }
+    return ensureDocumentIdentifier(brigadeRef, brigadeData || {}, 'brigade', brigadeId);
+}
+
+async function ensureUserBrigadesHaveIdentifiers(userId) {
+    if (!userId) return;
+    const snapshot = await db.collection('users').doc(userId).collection('userBrigades').get();
+    await Promise.all(snapshot.docs.map(async (membershipDoc) => {
+        const data = membershipDoc.data() || {};
+        if (normalizeSixDigitIdentifier(data.brigadeIdentifier)) return;
+
+        const brigadeRef = db.collection('brigades').doc(membershipDoc.id);
+        const brigadeDoc = await brigadeRef.get();
+        if (!brigadeDoc.exists) return;
+
+        const brigadeIdentifier = await ensureBrigadeIdentifier(membershipDoc.id, brigadeRef, brigadeDoc.data());
+        await membershipDoc.ref.set({ brigadeIdentifier }, { merge: true });
+    }));
+}
+
 // ===================================================================
 // NEW EMAIL TRIGGER FUNCTION
 // ===================================================================
@@ -132,6 +226,8 @@ apiRouter.post('/dev/seed-demo', async (req, res) => {
         const brigadeRef = db.collection('brigades').doc(brigadeId);
         const memberRef = brigadeRef.collection('members').doc(uid);
         const userBrigadeRef = db.collection('users').doc(uid).collection('userBrigades').doc(brigadeId);
+        const brigadeIdentifier = await ensureBrigadeIdentifier(brigadeId, brigadeRef);
+        const userIdentifier = await ensureUserIdentifier(uid);
 
         const demoApplianceData = {
             appliances: [
@@ -223,6 +319,7 @@ apiRouter.post('/dev/seed-demo', async (req, res) => {
                     stationNumber: '000',
                     region: 'Te Hiku',
                     creatorId: uid,
+                    identifier: brigadeIdentifier,
                     createdAt: FieldValue.serverTimestamp(),
                     applianceData: demoApplianceData,
                 });
@@ -234,6 +331,7 @@ apiRouter.post('/dev/seed-demo', async (req, res) => {
                         name: 'Demo Brigade',
                         stationNumber: '000',
                         region: 'Te Hiku',
+                        identifier: brigadeIdentifier,
                     },
                     { merge: true }
                 );
@@ -245,6 +343,7 @@ apiRouter.post('/dev/seed-demo', async (req, res) => {
                     role: 'Admin',
                     joinedAt: FieldValue.serverTimestamp(),
                     name: displayName,
+                    userIdentifier,
                 },
                 { merge: true }
             );
@@ -253,6 +352,7 @@ apiRouter.post('/dev/seed-demo', async (req, res) => {
                 userBrigadeRef,
                 {
                     brigadeName: 'Demo Brigade (000)',
+                    brigadeIdentifier,
                     role: 'Admin',
                 },
                 { merge: true }
@@ -427,10 +527,17 @@ userRouter.get('/:userId', async (req, res) => {
     try {
         const userDocRef = db.collection('users').doc(req.user.uid);
         const doc = await userDocRef.get();
+        const identifier = await ensureDocumentIdentifier(
+            userDocRef,
+            doc.exists ? doc.data() : {},
+            'user',
+            req.user.uid
+        );
+        await ensureUserBrigadesHaveIdentifiers(req.user.uid);
         if (doc.exists) {
-            return res.json(doc.data());
+            return res.json({ ...doc.data(), identifier });
         }
-        const defaultData = { appliances: [] };
+        const defaultData = { appliances: [], identifier };
         await db.collection('users').doc(req.user.uid).set(defaultData);
         return res.json({ ...defaultData, serverTime: new Date().toISOString() });
     } catch (err) {
@@ -441,7 +548,14 @@ userRouter.get('/:userId', async (req, res) => {
 userRouter.post('/:userId', async (req, res) => {
     try {
         const userDocRef = db.collection('users').doc(req.user.uid);
-        await userDocRef.set(req.body);
+        const doc = await userDocRef.get();
+        const identifier = await ensureDocumentIdentifier(
+            userDocRef,
+            doc.exists ? doc.data() : {},
+            'user',
+            req.user.uid
+        );
+        await userDocRef.set({ ...(req.body || {}), identifier });
         res.json({ message: 'Data saved successfully!' });
     } catch (err) {
         console.error('Error writing data to Firestore:', err);
@@ -459,15 +573,17 @@ brigadeRouter.get('/region/:regionName', async (req, res) => {
         const snapshot = await brigadesRef.where('region', '==', regionName).get();
         if (snapshot.empty) return res.json([]);
         // Only return safe public fields so non-members can't see brigade inventory data.
-        const brigades = snapshot.docs.map(doc => {
+        const brigades = await Promise.all(snapshot.docs.map(async (doc) => {
             const data = doc.data() || {};
+            const identifier = await ensureBrigadeIdentifier(doc.id, doc.ref, data);
             return {
                 id: doc.id,
                 name: data.name,
                 stationNumber: data.stationNumber,
                 region: data.region,
+                identifier,
             };
-        });
+        }));
         res.json(brigades);
     } catch (error) {
         console.error(`Error fetching brigades for region ${req.params.regionName}:`, error);
@@ -484,7 +600,14 @@ brigadeRouter.get('/:brigadeId/join-requests', async (req, res) => {
             return res.status(403).json({ message: 'Forbidden: You must be an admin to view join requests.' });
         }
         const requestsSnapshot = await db.collection('brigades').doc(brigadeId).collection('joinRequests').where('status', '==', 'pending').get();
-        const requests = requestsSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        const requests = await Promise.all(requestsSnapshot.docs.map(async (doc) => {
+            const data = doc.data() || {};
+            const userIdentifier = normalizeSixDigitIdentifier(data.userIdentifier) || await ensureUserIdentifier(doc.id);
+            if (!normalizeSixDigitIdentifier(data.userIdentifier) && userIdentifier) {
+                await doc.ref.set({ userIdentifier }, { merge: true });
+            }
+            return { id: doc.id, ...data, userIdentifier };
+        }));
         res.json(requests);
     } catch (error) {
         console.error(`Error fetching join requests for brigade ${req.params.brigadeId}:`, error);
@@ -511,10 +634,12 @@ brigadeRouter.post('/:brigadeId/join-requests', async (req, res) => {
         if (doc.exists) {
             return res.status(400).json({ message: 'You have already sent a join request to this brigade.' });
         }
+        const userIdentifier = await ensureUserIdentifier(userId);
         await joinRequestRef.set({
             status: 'pending',
             requestedAt: FieldValue.serverTimestamp(),
-            userName: userName || email
+            userName: userName || email,
+            userIdentifier,
         });
         res.status(201).json({ message: 'Your request to join has been sent.' });
     } catch (error) {
@@ -538,15 +663,18 @@ brigadeRouter.post('/:brigadeId/join-requests/:userId', async (req, res) => {
             if (!requestDoc.exists) {
                 return res.status(404).json({ message: 'Join request not found.' });
             }
-            const { userName } = requestDoc.data();
+            const requestData = requestDoc.data() || {};
+            const { userName } = requestData;
             const brigadeRef = db.collection('brigades').doc(brigadeId);
             const newMemberRef = brigadeRef.collection('members').doc(userId);
             const userBrigadeRef = db.collection('users').doc(userId).collection('userBrigades').doc(brigadeId);
             const brigadeDoc = await brigadeRef.get();
             const brigadeData = brigadeDoc.data();
+            const brigadeIdentifier = await ensureBrigadeIdentifier(brigadeId, brigadeRef, brigadeData);
+            const userIdentifier = normalizeSixDigitIdentifier(requestData.userIdentifier) || await ensureUserIdentifier(userId);
             await db.runTransaction(async (transaction) => {
-                transaction.set(newMemberRef, { role: 'Member', joinedAt: FieldValue.serverTimestamp(), name: userName });
-                transaction.set(userBrigadeRef, { brigadeName: `${brigadeData.name} (${brigadeData.stationNumber})`, role: 'Member' });
+                transaction.set(newMemberRef, { role: 'Member', joinedAt: FieldValue.serverTimestamp(), name: userName, userIdentifier });
+                transaction.set(userBrigadeRef, { brigadeName: `${brigadeData.name} (${brigadeData.stationNumber})`, brigadeIdentifier, role: 'Member' });
                 transaction.delete(requestRef);
             });
             res.status(200).json({ message: `User ${userName} has been added to the brigade.` });
@@ -583,9 +711,11 @@ brigadeRouter.post('/:brigadeId/members', async (req, res) => {
         const userBrigadeRef = userRef.collection('userBrigades').doc(brigadeId);
         const brigadeDoc = await brigadeRef.get();
         const brigadeData = brigadeDoc.data();
+        const brigadeIdentifier = await ensureBrigadeIdentifier(brigadeId, brigadeRef, brigadeData);
+        const userIdentifier = await ensureUserIdentifier(newMemberId);
         await db.runTransaction(async (transaction) => {
-            transaction.set(newMemberRef, { role: 'Member', joinedAt: FieldValue.serverTimestamp(), name: newMemberName });
-            transaction.set(userBrigadeRef, { brigadeName: `${brigadeData.name} (${brigadeData.stationNumber})`, role: 'Member' });
+            transaction.set(newMemberRef, { role: 'Member', joinedAt: FieldValue.serverTimestamp(), name: newMemberName, userIdentifier });
+            transaction.set(userBrigadeRef, { brigadeName: `${brigadeData.name} (${brigadeData.stationNumber})`, brigadeIdentifier, role: 'Member' });
         });
         res.status(201).json({ message: `User ${newMemberName} added to brigade successfully.` });
     } catch (error) {
@@ -799,11 +929,14 @@ brigadeRouter.post('/', async (req, res) => {
         }
         const newBrigadeRef = db.collection('brigades').doc();
         const brigadeId = newBrigadeRef.id;
+        const brigadeIdentifier = await reserveUniqueIdentifier('brigade', brigadeId);
+        const userIdentifier = await ensureUserIdentifier(creatorId);
         const newBrigadeData = {
             name: name,
             stationNumber: stationNumber,
             region: region,
             creatorId: creatorId,
+            identifier: brigadeIdentifier,
             createdAt: FieldValue.serverTimestamp(),
             applianceData: { appliances: [] }
         };
@@ -811,10 +944,10 @@ brigadeRouter.post('/', async (req, res) => {
         const userBrigadeRef = db.collection('users').doc(creatorId).collection('userBrigades').doc(brigadeId);
         await db.runTransaction(async (transaction) => {
             transaction.set(newBrigadeRef, newBrigadeData);
-            transaction.set(adminMemberRef, { role: 'Admin', joinedAt: FieldValue.serverTimestamp(), name: creatorName });
-            transaction.set(userBrigadeRef, { brigadeName: `${name} (${stationNumber})`, role: 'Admin' });
+            transaction.set(adminMemberRef, { role: 'Admin', joinedAt: FieldValue.serverTimestamp(), name: creatorName, userIdentifier });
+            transaction.set(userBrigadeRef, { brigadeName: `${name} (${stationNumber})`, brigadeIdentifier, role: 'Admin' });
         });
-        res.status(201).json({ message: 'Brigade created successfully!', brigadeId: brigadeId });
+        res.status(201).json({ message: 'Brigade created successfully!', brigadeId: brigadeId, identifier: brigadeIdentifier });
     } catch (error) {
         console.error('Error creating brigade:', error);
         res.status(500).json({ message: 'Failed to create brigade.' });
@@ -921,10 +1054,18 @@ brigadeRouter.get('/:brigadeId', async (req, res) => {
             return res.status(404).json({ message: 'Brigade not found.' });
         }
         const brigadeData = brigadeDoc.data();
+        const identifier = await ensureBrigadeIdentifier(brigadeId, brigadeRef, brigadeData);
         const membersCollectionRef = brigadeRef.collection('members');
         const membersSnapshot = await membersCollectionRef.get();
-        const members = membersSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-        res.status(200).json({ ...brigadeData, members: members });
+        const members = await Promise.all(membersSnapshot.docs.map(async (doc) => {
+            const data = doc.data() || {};
+            const userIdentifier = normalizeSixDigitIdentifier(data.userIdentifier) || await ensureUserIdentifier(doc.id);
+            if (!normalizeSixDigitIdentifier(data.userIdentifier) && userIdentifier) {
+                await doc.ref.set({ userIdentifier }, { merge: true });
+            }
+            return { id: doc.id, ...data, userIdentifier };
+        }));
+        res.status(200).json({ ...brigadeData, identifier, members: members });
     } catch (error) {
         console.error(`Error fetching brigade data for ${req.params.brigadeId}:`, error);
         res.status(500).json({ message: 'Failed to fetch brigade data.' });

--- a/public/js/app-shell/screens/account.js
+++ b/public/js/app-shell/screens/account.js
@@ -60,6 +60,10 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
   emailField.appendChild(emailLabel);
   emailField.appendChild(emailInput);
 
+  const identifierText = el("p", "text-sm");
+  identifierText.style.color = "var(--fs-muted)";
+  identifierText.textContent = "User ID: Loading...";
+
   const msg = el("p", "text-sm");
   msg.style.color = "var(--fs-muted)";
 
@@ -83,6 +87,7 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
   profileInner.appendChild(profileTitle);
   profileInner.appendChild(nameField);
   profileInner.appendChild(emailField);
+  profileInner.appendChild(identifierText);
   profileInner.appendChild(actions);
   profileInner.appendChild(msg);
   profileCard.appendChild(profileInner);
@@ -255,10 +260,17 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
     }
   });
 
+  async function loadProfile() {
+    const token = await user.getIdToken();
+    const data = await fetchJson(`/api/data/${encodeURIComponent(user.uid)}?t=${Date.now()}`, { token });
+    identifierText.textContent = data.identifier ? `User ID: ${data.identifier}` : "";
+  }
+
   // Load brigades list + allow leaving (async; don't block route transition).
   void (async () => {
     try {
-      const brigades = await getUserBrigades({ db, uid: user.uid });
+      await loadProfile();
+      const brigades = await getUserBrigades({ db, uid: user.uid, force: true });
       brigadeList.innerHTML = "";
 
       if (brigades.length === 0) {
@@ -269,9 +281,11 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
       brigades.forEach((b) => {
         const row = el("div", "fs-row");
         const left = el("div");
+        const brigadeIdentifier = b.brigadeIdentifier ? `Brigade ID: ${b.brigadeIdentifier}` : "";
         left.innerHTML = `
           <div class="fs-row-title">${b.brigadeName || b.id}</div>
           <div class="fs-row-meta">Role: ${b.role || "Member"}</div>
+          ${brigadeIdentifier ? `<div class="fs-row-meta fs-row-meta-subtle">${brigadeIdentifier}</div>` : ""}
         `;
         const right = el("div");
         const pill = el("span", `fs-pill ${String(b.role).toLowerCase() === "admin" ? "fs-pill-success" : ""}`);
@@ -298,6 +312,7 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
       });
     } catch (err) {
       console.error("Failed to load brigades (account):", err);
+      identifierText.textContent = "";
       brigadeList.innerHTML =
         '<div class="fs-row"><div><div class="fs-row-title">Could not load brigades</div><div class="fs-row-meta">Try again later.</div></div></div>';
     }

--- a/public/js/app-shell/screens/brigade.js
+++ b/public/js/app-shell/screens/brigade.js
@@ -145,7 +145,10 @@ export async function renderBrigade({ root, auth, brigadeId, setTitle, showLoadi
       const title = `${brigadeData.name} (${brigadeData.stationNumber})`;
       h2.textContent = title;
       setTitle?.(title);
-      sub.textContent = brigadeData.region ? `Region: ${brigadeData.region}` : "";
+      const brigadeMeta = [];
+      if (brigadeData.identifier) brigadeMeta.push(`Brigade ID: ${brigadeData.identifier}`);
+      if (brigadeData.region) brigadeMeta.push(`Region: ${brigadeData.region}`);
+      sub.textContent = brigadeMeta.join(" | ");
 
       const currentMembership = (brigadeData.members || []).find((m) => m.id === user.uid);
       const isAdmin = currentMembership && currentMembership.role === "Admin";
@@ -156,9 +159,12 @@ export async function renderBrigade({ root, auth, brigadeId, setTitle, showLoadi
 
         const left = el("div");
         const isSelf = member.id === user.uid;
+        const memberMeta = [];
+        if (member.userIdentifier) memberMeta.push(`User ID: ${member.userIdentifier}`);
+        if (member.email) memberMeta.push(member.email);
         left.innerHTML = `
           <div class="fs-row-title">${member.name || "N/A"}${isSelf ? " (you)" : ""}</div>
-          <div class="fs-row-meta">${member.email || ""}</div>
+          <div class="fs-row-meta">${memberMeta.join(" | ")}</div>
         `;
 
         const actions = el("div");
@@ -282,9 +288,12 @@ export async function renderBrigade({ root, auth, brigadeId, setTitle, showLoadi
       requests.forEach((req) => {
         const row = el("div", "fs-row");
         const left = el("div");
+        const requestMeta = [];
+        if (req.userIdentifier) requestMeta.push(`User ID: ${req.userIdentifier}`);
+        requestMeta.push(`Requested: ${safeFormatTimestamp(req.requestedAt)}`);
         left.innerHTML = `
           <div class="fs-row-title">${req.userName || req.id}</div>
-          <div class="fs-row-meta">Requested: ${safeFormatTimestamp(req.requestedAt)}</div>
+          <div class="fs-row-meta">${requestMeta.join(" | ")}</div>
         `;
 
         const right = el("div");

--- a/public/js/app-shell/screens/brigades.js
+++ b/public/js/app-shell/screens/brigades.js
@@ -318,9 +318,11 @@ export async function renderBrigades({ root, auth, db, showLoading, hideLoading 
         const row = el("div", "fs-row");
 
         const left = el("div");
+        const brigadeIdentifier = brigade.brigadeIdentifier ? `Brigade ID: ${brigade.brigadeIdentifier}` : "";
         left.innerHTML = `
           <div class="fs-row-title">${brigade.brigadeName || "Brigade"}</div>
           <div class="fs-row-meta">Role: ${brigade.role || "Member"}</div>
+          ${brigadeIdentifier ? `<div class="fs-row-meta fs-row-meta-subtle">${brigadeIdentifier}</div>` : ""}
         `;
 
         const actions = el("div");
@@ -397,9 +399,11 @@ export async function renderBrigades({ root, auth, db, showLoading, hideLoading 
       brigades.forEach((brigade) => {
         const row = el("div", "fs-row");
         const left = el("div");
+        const brigadeIdentifier = brigade.identifier ? `Brigade ID: ${brigade.identifier}` : "";
         left.innerHTML = `
           <div class="fs-row-title">${brigade.name} (${brigade.stationNumber})</div>
-          <div class="fs-row-meta">Region: ${brigade.region || ""}</div>
+          <div class="fs-row-meta">${brigadeIdentifier || "Brigade ID unavailable"}</div>
+          <div class="fs-row-meta fs-row-meta-subtle">Region: ${brigade.region || ""}</div>
         `;
         const btn = el("button", "fs-btn fs-btn-primary");
         btn.type = "button";
@@ -460,5 +464,5 @@ export async function renderBrigades({ root, auth, db, showLoading, hideLoading 
   });
 
   // Initial hydrate without blocking route transition.
-  void refreshMyBrigades();
+  void refreshMyBrigades({ force: true });
 }

--- a/public/js/brigade-management.js
+++ b/public/js/brigade-management.js
@@ -89,6 +89,12 @@ async function loadBrigadeData() {
         
         // Update UI with brigade data
         brigadeNameHeader.textContent = `${brigadeData.name} (${brigadeData.stationNumber})`;
+        if (brigadeData.identifier) {
+            const identifierEl = document.createElement('p');
+            identifierEl.className = 'text-sm font-normal';
+            identifierEl.textContent = `Brigade ID: ${brigadeData.identifier}`;
+            brigadeNameHeader.appendChild(identifierEl);
+        }
         
         // Check user's role and show admin tools if applicable
         const currentUserMembership = brigadeData.members.find(m => m.id === currentUser.uid);
@@ -129,6 +135,7 @@ async function loadBrigadeData() {
             memberElement.innerHTML = `
                 <div>
                     <p class="text-lg font-semibold">${member.name || 'N/A'}</p>
+                    ${member.userIdentifier ? `<p class="text-sm text-gray-500">User ID: ${member.userIdentifier}</p>` : ''}
                     ${!isCurrentUserAdmin ? `<p class="text-gray-600">Role: ${member.role}</p>`: ''}
                 </div>
                 ${adminControls}
@@ -170,6 +177,7 @@ async function loadJoinRequests() {
             reqElement.innerHTML = `
                 <div>
                     <p class="font-semibold">${req.userName}</p>
+                    ${req.userIdentifier ? `<p class="text-sm text-gray-500">User ID: ${req.userIdentifier}</p>` : ''}
                     <p class="text-sm text-gray-500">Requested on: ${new Date(req.requestedAt._seconds * 1000).toLocaleString()}</p>
                 </div>
                 <div>

--- a/public/manage-brigades.html
+++ b/public/manage-brigades.html
@@ -284,6 +284,7 @@
                             <div>
                                 <h3 class="text-xl font-bold">${brigade.brigadeName}</h3>
                                 <p class="text-gray-600">Your Role: <span class="font-semibold">${brigade.role}</span></p>
+                                ${brigade.brigadeIdentifier ? `<p class="text-sm text-gray-500">Brigade ID: ${brigade.brigadeIdentifier}</p>` : ''}
                             </div>
                             <div class="flex items-center">
                                 <button class="bg-blue text-white font-semibold py-2 px-4 rounded-lg" onclick="manageBrigade('${doc.id}')">Manage</button>
@@ -415,6 +416,7 @@
                     brigadeElement.innerHTML = `
                         <div>
                             <h3 class="text-xl font-bold">${brigade.name} (${brigade.stationNumber})</h3>
+                            ${brigade.identifier ? `<p class="text-sm text-gray-500">Brigade ID: ${brigade.identifier}</p>` : ''}
                         </div>
                         <button id="join-btn-${brigade.id}" class="bg-green-action-1 text-white font-semibold py-2 px-4 rounded-lg" onclick="requestToJoin('${brigade.id}')">Request to Join</button>
                     `;


### PR DESCRIPTION
## Summary
- add six-digit unique identifiers for users and brigades using a Firestore registry
- store identifiers on brigade, user, member, join request, and userBrigades records
- show brigade IDs in join/search and membership lists, and user IDs under users/members

## Validation
- node --check functions/index.js
- node --check public/js/app-shell/screens/account.js
- node --check public/js/app-shell/screens/brigade.js
- node --check public/js/app-shell/screens/brigades.js
- node --check public/js/brigade-management.js
- git diff --check