### PR TITLE
[codex] Add account autosave and report email preferences

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -48,11 +48,13 @@ const transporter = nodemailer.createTransport({
 });
 const DEFAULT_FROM_EMAIL = smtpConfig.from || "hello@theblueprintcollective.co.nz";
 const REPORT_EXPORT_DOWNLOAD_TTL_MS = 10 * 60 * 1000;
+const REPORT_EMAIL_PREFERENCE_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 const USER_IDENTIFIER_PREFIX = 'U';
 const BRIGADE_IDENTIFIER_PREFIX = 'B';
 const CHECK_LOCK_TTL_MS = 12 * 60 * 60 * 1000;
 const CHECK_EDITOR_LEASE_MS = 15 * 60 * 1000;
 const IMAGE_UPLOAD_PREFIX = 'uploads';
+const APP_BASE_URL = (functions.config().app && functions.config().app.url) || 'https://flashoverapplication.web.app';
 const ROLES = Object.freeze({
     ADMIN: 'admin',
     GEAR_MANAGER: 'gearManager',
@@ -124,6 +126,81 @@ function canRunChecks(role) {
 
 function canViewReports(role) {
     return !!normalizeRole(role);
+}
+
+function defaultReportEmailsEnabled(role) {
+    const normalized = normalizeRole(role);
+    return normalized === ROLES.ADMIN || normalized === ROLES.GEAR_MANAGER;
+}
+
+function cleanOptionalBoolean(value, label) {
+    if (value == null || value === '') return null;
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') {
+        if (value === 1) return true;
+        if (value === 0) return false;
+    }
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+        if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+    }
+    const error = new Error(`${label} must be true or false.`);
+    error.status = 400;
+    throw error;
+}
+
+function explicitReportEmailPreference(profile) {
+    if (!isPlainObject(profile)) return null;
+    if (typeof profile.reportEmailPreference === 'boolean') return profile.reportEmailPreference;
+    if (isPlainObject(profile.emailPreferences)) {
+        const direct = profile.emailPreferences.reportEmails;
+        if (typeof direct === 'boolean') return direct;
+    }
+    if (typeof profile.reportEmailsEnabled === 'boolean') return profile.reportEmailsEnabled;
+    return null;
+}
+
+function shouldReceiveReportEmails(role, reportEmailPreference = null) {
+    const explicit = typeof reportEmailPreference === 'boolean'
+        ? reportEmailPreference
+        : cleanOptionalBoolean(reportEmailPreference, 'Report email preference');
+    if (typeof explicit === 'boolean') return explicit;
+    return defaultReportEmailsEnabled(role);
+}
+
+function shouldSendReportEmails(role, profile) {
+    return shouldReceiveReportEmails(role, explicitReportEmailPreference(profile));
+}
+
+function normalizeEmailAddress(value) {
+    return cleanOptionalText(value, 'Email', 254);
+}
+
+function buildPublicBaseUrl(req) {
+    const fallback = APP_BASE_URL;
+    try {
+        const host = cleanOptionalText(
+            req && typeof req.get === 'function' ? req.get('host') : '',
+            'Host',
+            255
+        );
+        if (!host) return fallback;
+        const rawProto = cleanOptionalText(
+            req && typeof req.get === 'function' ? req.get('x-forwarded-proto') : (req && req.protocol) || '',
+            'Protocol',
+            16
+        );
+        const proto = String(rawProto || 'https').split(',')[0].trim().toLowerCase();
+        const safeProto = proto === 'http' ? 'http' : 'https';
+        return `${safeProto}://${host}`;
+    } catch (error) {
+        return fallback;
+    }
+}
+
+function buildReportEmailUnsubscribeUrl(req, token) {
+    return new URL(`/api/report-email-unsubscribe/${encodeURIComponent(token)}`, buildPublicBaseUrl(req)).toString();
 }
 
 function displayNameFromProfile(profile, fallback = 'Unknown') {
@@ -349,6 +426,27 @@ function checkLockResponse(lock, requesterUid) {
         isMine: lock.uid === requesterUid,
         previousLock: lock.previousLock,
     };
+}
+
+function toIsoString(value) {
+    if (!value) return '';
+    if (typeof value === 'string') return value;
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value.toDate === 'function') {
+        try {
+            return value.toDate().toISOString();
+        } catch (error) {
+            return '';
+        }
+    }
+    if (typeof value._seconds === 'number') {
+        try {
+            return new Date(value._seconds * 1000).toISOString();
+        } catch (error) {
+            return '';
+        }
+    }
+    return '';
 }
 
 function findApplianceIndex(applianceData, applianceId) {
@@ -742,7 +840,84 @@ async function createOrClaimCheckSession({ brigadeId, appliance, requester, forc
 
 function checkSessionResponse(sessionDoc, answers = []) {
     const data = sessionDoc && typeof sessionDoc.data === 'function' ? sessionDoc.data() || {} : sessionDoc || {};
-    return { session: { id: sessionDoc.id || data.id, ...data }, answers };
+    const session = { id: sessionDoc.id || data.id, ...data };
+    [
+        'startedAt',
+        'updatedAt',
+        'lastSavedAt',
+        'editorLeaseExpiresAt',
+        'completedAt',
+        'cancelledAt',
+        'createdAt',
+    ].forEach((field) => {
+        if (field in session) session[field] = toIsoString(session[field]);
+    });
+    return { session, answers };
+}
+
+function reportEmailUnsubscribeTokenRef(token) {
+    return db.collection('reportEmailUnsubscribes').doc(token);
+}
+
+async function createReportEmailUnsubscribeToken({ userId, email, brigadeId, reportId = '' }) {
+    if (!userId || !email) return '';
+    const token = crypto.randomBytes(32).toString('hex');
+    await reportEmailUnsubscribeTokenRef(token).set({
+        token,
+        userId,
+        email,
+        brigadeId: brigadeId || '',
+        reportId: reportId || '',
+        purpose: 'reportEmails',
+        status: 'active',
+        createdAt: FieldValue.serverTimestamp(),
+        expiresAt: Timestamp.fromDate(new Date(Date.now() + REPORT_EMAIL_PREFERENCE_TOKEN_TTL_MS)),
+    });
+    return token;
+}
+
+async function listReportEmailRecipients(brigadeId) {
+    const membersSnapshot = await db.collection('brigades').doc(brigadeId).collection('members').get();
+    const recipients = [];
+    const seenEmails = new Set();
+    for (const memberDoc of membersSnapshot.docs) {
+        const memberData = memberDoc.data() || {};
+        const profile = await getUserProfile(memberDoc.id);
+        const email = cleanOptionalText((profile && profile.email) || memberData.email, 'Email', 254);
+        if (!email) continue;
+        if (!shouldReceiveReportEmails(memberData.role, explicitReportEmailPreference(profile))) continue;
+        const normalizedEmail = email.toLowerCase();
+        if (seenEmails.has(normalizedEmail)) continue;
+        seenEmails.add(normalizedEmail);
+        recipients.push({ userId: memberDoc.id, email });
+    }
+    return recipients;
+}
+
+async function queueReportNotificationEmails({ brigadeId, reportData, req, subject }) {
+    const recipients = await listReportEmailRecipients(brigadeId);
+    if (recipients.length === 0) return 0;
+
+    await Promise.all(recipients.map(async ({ userId, email }) => {
+        const unsubscribeToken = await createReportEmailUnsubscribeToken({
+            userId,
+            email,
+            brigadeId,
+            reportId: reportData && reportData.reportId ? reportData.reportId : '',
+        });
+        const emailHtml = generateReportHtml(reportData, {
+            unsubscribeUrl: buildReportEmailUnsubscribeUrl(req, unsubscribeToken),
+        });
+        return db.collection('mail').add({
+            to: email,
+            message: {
+                subject,
+                html: emailHtml,
+            },
+            createdAt: FieldValue.serverTimestamp(),
+        });
+    }));
+    return recipients.length;
 }
 
 function identifierPrefix(ownerType) {
@@ -842,6 +1017,9 @@ async function ensureUserProfile(user) {
         updatedAt: FieldValue.serverTimestamp(),
     };
     if (fullName) patch.fullName = fullName;
+    if (current.emailPreferences && isPlainObject(current.emailPreferences) && typeof current.emailPreferences.reportEmails === 'boolean') {
+        patch.emailPreferences = current.emailPreferences;
+    }
     if (!doc.exists) patch.createdAt = FieldValue.serverTimestamp();
     await ref.set(patch, { merge: true });
     return { id: user.uid, ...current, fullName, email, identifier };
@@ -1393,6 +1571,7 @@ userRouter.get('/:userId', async (req, res) => {
             ...profile,
             fullName: profile.fullName || '',
             email: profile.email || req.user.email || '',
+            reportEmailPreference: explicitReportEmailPreference(profile),
             serverTime: new Date().toISOString(),
         });
     } catch (err) {
@@ -1414,11 +1593,23 @@ userRouter.post('/:userId', async (req, res) => {
             req.user.uid
         );
         const body = isPlainObject(req.body) ? req.body : {};
+        const existingProfileData = doc.exists ? doc.data() || {} : {};
         const patch = { identifier, updatedAt: FieldValue.serverTimestamp() };
         const fullName = cleanOptionalText(body.fullName || body.name, 'Full name', 160);
         if (fullName) patch.fullName = fullName;
         const email = cleanOptionalText(body.email || req.user.email, 'Email', 254);
         if (email) patch.email = email;
+        const reportEmailPreference = cleanOptionalBoolean(
+            body.reportEmailPreference ?? body.reportEmails ?? body.emailPreferences?.reportEmails,
+            'Report email preference'
+        );
+        if (reportEmailPreference !== null) {
+            patch.reportEmailPreference = reportEmailPreference;
+            patch.emailPreferences = {
+                ...(isPlainObject(existingProfileData.emailPreferences) ? existingProfileData.emailPreferences : {}),
+                reportEmails: reportEmailPreference,
+            };
+        }
         if (isPlainObject(body.termsAcceptance)) {
             const version = cleanOptionalText(body.termsAcceptance.version, 'Terms version', 40);
             if (version) {
@@ -2338,6 +2529,7 @@ brigadeRouter.post('/:brigadeId/check-sessions/:sessionId/complete', async (req,
         };
         const reportRef = brigade.ref.collection('reports').doc();
         await reportRef.set(safeReportData);
+        safeReportData.reportId = reportRef.id;
         if (signature) {
             await reportRef.collection('meta').doc('signoff').set({
                 signature,
@@ -2360,22 +2552,14 @@ brigadeRouter.post('/:brigadeId/check-sessions/:sessionId/complete', async (req,
             transaction.set(appliance.ref, { checkStatus: FieldValue.delete(), updatedAt: FieldValue.serverTimestamp() }, { merge: true });
         });
         try {
-            const membersSnapshot = await db.collection('brigades').doc(brigadeId).collection('members').get();
-            const recipients = [];
-            for (const memberDoc of membersSnapshot.docs) {
-                const memberProfile = await getUserProfile(memberDoc.id);
-                if (memberProfile && memberProfile.email) recipients.push(memberProfile.email);
-            }
-            if (recipients.length > 0) {
-                const emailHtml = generateReportHtml(safeReportData);
-                await Promise.all(recipients.map((email) => db.collection('mail').add({
-                    to: email,
-                    message: {
-                        subject: `New Report Submitted for ${safeReportData.applianceName}`,
-                        html: emailHtml,
-                    },
-                    createdAt: FieldValue.serverTimestamp(),
-                })));
+            const queuedCount = await queueReportNotificationEmails({
+                brigadeId,
+                reportData: safeReportData,
+                req,
+                subject: `New Report Submitted for ${safeReportData.applianceName}`,
+            });
+            if (queuedCount > 0) {
+                console.log(`Successfully queued emails for ${queuedCount} brigade members.`);
             }
         } catch (emailError) {
             console.error('Failed to queue report emails:', emailError);
@@ -2852,7 +3036,7 @@ reportRouter.get('/brigade/:brigadeId', async (req, res) => {
     }
 });
 // A helper function to generate a clearer HTML email for the report
-const generateReportHtml = (reportData) => {
+const generateReportHtml = (reportData, options = {}) => {
     const {
         applianceName = 'Unknown Appliance',
         date,
@@ -2860,6 +3044,7 @@ const generateReportHtml = (reportData) => {
         signedName,
         lockers = [],
     } = reportData || {};
+    const unsubscribeUrl = cleanOptionalText(options.unsubscribeUrl, 'Unsubscribe URL', 500) || '';
 
     const completedBy = String(signedName || '').trim() || username;
 
@@ -3035,6 +3220,10 @@ const generateReportHtml = (reportData) => {
         html += `<p>No checklist items in this report.</p>`;
     }
 
+    if (unsubscribeUrl) {
+        html += `<p style="margin: 20px 0 0 0; font-size: 12px; color: #6b7280;">To stop report emails, <a href="${unsubscribeUrl}" style="color: #2563eb;">unsubscribe here</a>.</p>`;
+    }
+
     html += `</div></div>`;
     return html;
 };
@@ -3088,6 +3277,7 @@ reportRouter.post('/', async (req, res) => {
         const reportRef = brigade.ref.collection('reports').doc();
         await reportRef.set(safeReportData);
         const reportId = reportRef.id;
+        safeReportData.reportId = reportId;
 
         // Store the signature separately so large reports don't risk hitting Firestore's 1MiB document limit.
         if (signature) {
@@ -3115,29 +3305,14 @@ reportRouter.post('/', async (req, res) => {
             console.error('Failed to clear report author check lock:', lockError);
         }
         try {
-            const membersSnapshot = await db.collection('brigades').doc(brigadeId).collection('members').get();
-            if (!membersSnapshot.empty) {
-                const memberIds = membersSnapshot.docs.map(doc => doc.id);
-                const profiles = await Promise.all(memberIds.map(uid => getUserProfile(uid)));
-                const recipients = profiles.map(userProfile => userProfile && userProfile.email).filter(email => !!email);
-                if (recipients.length > 0) {
-                    
-                    // Generate the rich HTML content for the email
-                    const emailHtml = generateReportHtml(safeReportData);
-
-                    const mailCollection = db.collection('mail');
-                    const emailPromises = recipients.map(email => {
-                        return mailCollection.add({
-                            to: email,
-                            message: {
-                                subject: `New Report Submitted for ${safeReportData.applianceName}`,
-                                html: emailHtml, // Use the new, detailed HTML
-                            },
-                        });
-                    });
-                    await Promise.all(emailPromises);
-                    console.log(`Successfully queued emails for ${recipients.length} brigade members.`);
-                }
+            const queuedCount = await queueReportNotificationEmails({
+                brigadeId,
+                reportData: safeReportData,
+                req,
+                subject: `New Report Submitted for ${safeReportData.applianceName}`,
+            });
+            if (queuedCount > 0) {
+                console.log(`Successfully queued emails for ${queuedCount} brigade members.`);
             }
         } catch (emailError) {
             console.error("Failed to send email notifications:", emailError);
@@ -3204,6 +3379,70 @@ app.get('/api/report-export-downloads/:token.pdf', async (req, res) => {
             ? 'Failed to download report export.'
             : (error && error.message ? error.message : 'Report export download link is no longer available.');
         return res.status(status).json({ message });
+    }
+});
+
+app.get('/api/report-email-unsubscribe/:token', async (req, res) => {
+    const token = String(req.params.token || '').trim();
+    if (!/^[a-f0-9]{64}$/.test(token)) {
+        return res.status(404).type('html').send('<!doctype html><html><body><p>Unsubscribe link not found.</p></body></html>');
+    }
+
+    try {
+        const tokenRef = db.collection('reportEmailUnsubscribes').doc(token);
+        const tokenDoc = await tokenRef.get();
+        if (!tokenDoc.exists) {
+            return res.status(404).type('html').send('<!doctype html><html><body><p>Unsubscribe link not found.</p></body></html>');
+        }
+
+        const tokenData = tokenDoc.data() || {};
+        const expiresAtMs = timestampToMillis(tokenData.expiresAt);
+        if (Number.isFinite(expiresAtMs) && expiresAtMs <= Date.now()) {
+            return res.status(404).type('html').send('<!doctype html><html><body><p>Unsubscribe link not found.</p></body></html>');
+        }
+        const userId = String(tokenData.userId || '').trim();
+        if (userId) {
+            const userRef = db.collection('users').doc(userId);
+            const userDoc = await userRef.get();
+            const existingProfileData = userDoc.exists ? userDoc.data() || {} : {};
+            const identifier = await ensureDocumentIdentifier(
+                userRef,
+                existingProfileData,
+                'user',
+                userId
+            );
+            await userRef.set({
+                identifier,
+                reportEmailPreference: false,
+                emailPreferences: {
+                    ...(isPlainObject(existingProfileData.emailPreferences) ? existingProfileData.emailPreferences : {}),
+                    reportEmails: false,
+                },
+                reportEmailPreferenceUpdatedAt: FieldValue.serverTimestamp(),
+                updatedAt: FieldValue.serverTimestamp(),
+            }, { merge: true });
+        }
+
+        await tokenRef.set({
+            status: 'unsubscribed',
+            unsubscribedAt: FieldValue.serverTimestamp(),
+            updatedAt: FieldValue.serverTimestamp(),
+        }, { merge: true });
+
+        return res.status(200).type('html').send(`<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Unsubscribed</title>
+</head>
+<body>
+    <p>You have been unsubscribed from report emails.</p>
+</body>
+</html>`);
+    } catch (error) {
+        console.error('Error processing report email unsubscribe:', error);
+        return res.status(500).type('html').send('<!doctype html><html><body><p>Unable to process unsubscribe request.</p></body></html>');
     }
 });
 

--- a/public/js/app-shell/screens/account.js
+++ b/public/js/app-shell/screens/account.js
@@ -1,4 +1,4 @@
-import { getUserBrigades } from "../cache.js";
+import { getUserBrigades, invalidateUserBrigades } from "../cache.js";
 
 function el(tag, className) {
   const node = document.createElement(tag);
@@ -43,6 +43,56 @@ function isAdminRole(role) {
   return normalizeRole(role) === "admin";
 }
 
+function parseBooleanPreference(value) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) return true;
+    if (["false", "0", "no", "off"].includes(normalized)) return false;
+  }
+  return null;
+}
+
+function getReportEmailPreference(profile) {
+  if (!profile || typeof profile !== "object") return null;
+  const candidates = [
+    profile.reportEmails,
+    profile.reportEmail,
+    profile.reportEmailOptIn,
+    profile.reportEmailPreference,
+    profile.reportEmailsEnabled,
+    profile.receiveReportEmails,
+    profile.emailPreferences && profile.emailPreferences.reportEmails,
+    profile.emailPreferences && profile.emailPreferences.reportEmail,
+    profile.emailPreferences && profile.emailPreferences.reportEmailOptIn,
+    profile.emailPreferences && profile.emailPreferences.reportEmailPreference,
+    profile.emailPreferences && profile.emailPreferences.reportEmailsEnabled,
+    profile.emailPreferences && profile.emailPreferences.receiveReportEmails,
+    profile.preferences && profile.preferences.reportEmails,
+    profile.preferences && profile.preferences.reportEmail,
+    profile.preferences && profile.preferences.reportEmailOptIn,
+    profile.preferences && profile.preferences.reportEmailPreference,
+    profile.preferences && profile.preferences.reportEmailsEnabled,
+    profile.preferences && profile.preferences.receiveReportEmails,
+  ];
+  for (const candidate of candidates) {
+    const parsed = parseBooleanPreference(candidate);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function brigadesGrantReportEmailsByDefault(brigades = []) {
+  return brigades.some((brigade) => {
+    const role = normalizeRole(brigade?.role);
+    return role === "admin" || role === "gearManager";
+  });
+}
+
 export async function renderAccount({ root, auth, db, showLoading, hideLoading }) {
   root.innerHTML = "";
 
@@ -82,6 +132,33 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
   emailField.appendChild(emailLabel);
   emailField.appendChild(emailInput);
 
+  const reportEmailsField = el("div", "fs-field");
+  const reportEmailsLabel = el("label", "fs-label");
+  reportEmailsLabel.textContent = "Report emails";
+  const reportEmailsRow = el("label");
+  reportEmailsRow.style.display = "flex";
+  reportEmailsRow.style.alignItems = "flex-start";
+  reportEmailsRow.style.gap = "10px";
+  reportEmailsRow.style.cursor = "pointer";
+  const reportEmailsCheckbox = el("input");
+  reportEmailsCheckbox.type = "checkbox";
+  reportEmailsCheckbox.style.marginTop = "4px";
+  const reportEmailsCopy = el("div");
+  const reportEmailsCopyTitle = el("div");
+  reportEmailsCopyTitle.style.fontWeight = "600";
+  reportEmailsCopyTitle.textContent = "Receive report emails";
+  const reportEmailsCopyBody = el("div");
+  reportEmailsCopyBody.style.color = "var(--fs-muted)";
+  reportEmailsCopyBody.style.fontSize = "13px";
+  reportEmailsCopyBody.textContent =
+    "Admins and gear managers get report emails by default. Everyone else can opt in.";
+  reportEmailsCopy.appendChild(reportEmailsCopyTitle);
+  reportEmailsCopy.appendChild(reportEmailsCopyBody);
+  reportEmailsRow.appendChild(reportEmailsCheckbox);
+  reportEmailsRow.appendChild(reportEmailsCopy);
+  reportEmailsField.appendChild(reportEmailsLabel);
+  reportEmailsField.appendChild(reportEmailsRow);
+
   const identifierText = el("p", "text-sm");
   identifierText.style.color = "var(--fs-muted)";
   identifierText.textContent = "User ID: Loading...";
@@ -90,10 +167,6 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
   msg.style.color = "var(--fs-muted)";
 
   const actions = el("div", "fs-actions");
-  const saveBtn = el("button", "fs-btn fs-btn-primary");
-  saveBtn.type = "button";
-  saveBtn.textContent = "Save profile";
-
   const resetBtn = el("button", "fs-btn fs-btn-secondary");
   resetBtn.type = "button";
   resetBtn.textContent = "Send password reset email";
@@ -102,13 +175,13 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
   signOutBtn.type = "button";
   signOutBtn.textContent = "Sign out";
 
-  actions.appendChild(saveBtn);
   actions.appendChild(resetBtn);
   actions.appendChild(signOutBtn);
 
   profileInner.appendChild(profileTitle);
   profileInner.appendChild(nameField);
   profileInner.appendChild(emailField);
+  profileInner.appendChild(reportEmailsField);
   profileInner.appendChild(identifierText);
   profileInner.appendChild(actions);
   profileInner.appendChild(msg);
@@ -162,10 +235,83 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
   document.body.appendChild(actionSheet);
 
   let actionBrigade = null;
+  let isHydratingProfile = true;
+  let saveTimer = null;
+  let latestSaveToken = 0;
+  let lastSavedProfileState = null;
   const renderEmptyBrigades = () => {
     brigadeList.innerHTML =
       '<div class="fs-row"><div><div class="fs-row-title">No brigades yet</div><div class="fs-row-meta">Join or create a brigade from the Brigades tab.</div></div></div>';
   };
+
+  function currentProfileState() {
+    return {
+      fullName: nameInput.value.trim(),
+      reportEmails: !!reportEmailsCheckbox.checked,
+    };
+  }
+
+  function sameProfileState(a, b) {
+    return !!a && !!b && a.fullName === b.fullName && a.reportEmails === b.reportEmails;
+  }
+
+  function setMessage(text, color = "var(--fs-muted)") {
+    msg.style.color = color;
+    msg.textContent = text || "";
+  }
+
+  async function persistProfile() {
+    if (isHydratingProfile) return;
+    const nextState = currentProfileState();
+    if (!nextState.fullName) {
+      setMessage("Full name is required.", "var(--red-action-2)");
+      return;
+    }
+    if (nextState.fullName.length > 60) {
+      setMessage("Name is too long.", "var(--red-action-2)");
+      return;
+    }
+    if (sameProfileState(nextState, lastSavedProfileState)) {
+      return;
+    }
+
+    const saveToken = ++latestSaveToken;
+    setMessage("Saving…");
+    try {
+      await user.updateProfile({ displayName: nextState.fullName });
+      const token = await user.getIdToken();
+      await fetchJson(`/api/data/${encodeURIComponent(user.uid)}`, {
+        token,
+        method: "POST",
+        body: {
+          fullName: nextState.fullName,
+          email: user.email || emailInput.value.trim(),
+          reportEmailPreference: nextState.reportEmails,
+          reportEmails: nextState.reportEmails,
+          emailPreferences: {
+            reportEmails: nextState.reportEmails,
+          },
+        },
+      });
+      lastSavedProfileState = nextState;
+      if (saveToken === latestSaveToken) {
+        setMessage("Saved.");
+      }
+    } catch (err) {
+      console.error("Failed to save profile:", err);
+      if (saveToken === latestSaveToken) {
+        setMessage(err.message || "Failed to save.", "var(--red-action-2)");
+      }
+    }
+  }
+
+  function scheduleProfileSave(delay = 700) {
+    if (saveTimer) window.clearTimeout(saveTimer);
+    saveTimer = window.setTimeout(() => {
+      saveTimer = null;
+      void persistProfile();
+    }, delay);
+  }
 
   function openActionSheet(brigade) {
     actionBrigade = brigade;
@@ -179,30 +325,80 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
     actionBrigade = null;
   }
 
+  sheet.addEventListener("click", (e) => {
+    e.stopPropagation();
+  });
+
   actionSheet.addEventListener("click", (e) => {
     if (e.target === actionSheet) closeActionSheet();
   });
 
+  async function refreshBrigadesList({ force = false } = {}) {
+    const brigades = await getUserBrigades({ db, uid: user.uid, force });
+    brigadeList.innerHTML = "";
+
+    if (brigades.length === 0) {
+      renderEmptyBrigades();
+      return;
+    }
+
+    brigades.forEach((b) => {
+      const displayRole = roleLabel(b.role);
+      const row = el("div", "fs-row");
+      const left = el("div");
+      const brigadeIdentifier = b.brigadeIdentifier ? `Brigade ID: ${b.brigadeIdentifier}` : "";
+      left.innerHTML = `
+        <div class="fs-row-title">${b.brigadeName || b.id}</div>
+        <div class="fs-row-meta">Role: ${displayRole}</div>
+        ${brigadeIdentifier ? `<div class="fs-row-meta fs-row-meta-subtle">${brigadeIdentifier}</div>` : ""}
+      `;
+      const right = el("div");
+      const pill = el("span", `fs-pill ${isAdminRole(b.role) ? "fs-pill-success" : ""}`);
+      pill.textContent = displayRole;
+
+      const menuBtn = el("button", "fs-icon-btn");
+      menuBtn.type = "button";
+      menuBtn.textContent = "⋯";
+      menuBtn.setAttribute("aria-label", "More actions");
+
+      right.style.display = "flex";
+      right.style.gap = "8px";
+      right.style.alignItems = "center";
+      right.appendChild(pill);
+      right.appendChild(menuBtn);
+
+      menuBtn.addEventListener("click", () => {
+        openActionSheet({ ...b, row });
+      });
+
+      row.appendChild(left);
+      row.appendChild(right);
+      brigadeList.appendChild(row);
+    });
+  }
+
   sheetCancel.addEventListener("click", closeActionSheet);
   sheetManage.addEventListener("click", () => {
-    if (!actionBrigade) return;
+    const brigade = actionBrigade;
+    if (!brigade) return;
     closeActionSheet();
-    window.location.hash = `#/brigade/${encodeURIComponent(actionBrigade.id)}`;
+    window.location.hash = `#/brigade/${encodeURIComponent(brigade.id)}`;
   });
   sheetLeave.addEventListener("click", async () => {
-    if (!actionBrigade) return;
-    const name = actionBrigade.brigadeName || actionBrigade.id;
+    const brigade = actionBrigade;
+    if (!brigade) return;
+    const name = brigade.brigadeName || brigade.id;
     if (!confirm(`Leave brigade: ${name}?`)) return;
     closeActionSheet();
     showLoading?.();
     try {
       const token = await user.getIdToken();
-      await fetchJson(`/api/brigades/${encodeURIComponent(actionBrigade.id)}/leave`, {
+      await fetchJson(`/api/brigades/${encodeURIComponent(brigade.id)}/leave`, {
         token,
         method: "POST",
       });
-      actionBrigade.row?.remove();
-      if (brigadeList.children.length === 0) renderEmptyBrigades();
+      invalidateUserBrigades(user.uid);
+      await refreshBrigadesList({ force: true });
     } catch (err) {
       alert(err.message || "Failed to leave brigade.");
     } finally {
@@ -210,8 +406,9 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
     }
   });
   sheetDelete.addEventListener("click", async () => {
-    if (!actionBrigade) return;
-    const name = actionBrigade.brigadeName || actionBrigade.id;
+    const brigade = actionBrigade;
+    if (!brigade) return;
+    const name = brigade.brigadeName || brigade.id;
     if (!confirm(`Are you sure you want to delete the brigade "${name}"? This will remove all members and cannot be undone.`)) {
       return;
     }
@@ -220,12 +417,12 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
     showLoading?.();
     try {
       const token = await user.getIdToken();
-      await fetchJson(`/api/brigades/${encodeURIComponent(actionBrigade.id)}`, {
+      await fetchJson(`/api/brigades/${encodeURIComponent(brigade.id)}`, {
         token,
         method: "DELETE",
       });
-      actionBrigade.row?.remove();
-      if (brigadeList.children.length === 0) renderEmptyBrigades();
+      invalidateUserBrigades(user.uid);
+      await refreshBrigadesList({ force: true });
     } catch (err) {
       alert(err.message || "Failed to delete brigade.");
     } finally {
@@ -233,36 +430,37 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
     }
   });
 
-  saveBtn.addEventListener("click", async () => {
+  nameInput.addEventListener("input", () => {
+    if (isHydratingProfile) return;
     const nextName = nameInput.value.trim();
     if (!nextName) {
-      msg.style.color = "var(--red-action-2)";
-      msg.textContent = "Full name is required.";
+      setMessage("Full name is required.", "var(--red-action-2)");
       return;
     }
     if (nextName.length > 60) {
-      msg.textContent = "Name is too long.";
+      setMessage("Name is too long.", "var(--red-action-2)");
       return;
     }
-    showLoading?.();
-    msg.textContent = "";
-    try {
-      await user.updateProfile({ displayName: nextName });
-      const token = await user.getIdToken();
-      await fetchJson(`/api/data/${encodeURIComponent(user.uid)}`, {
-        token,
-        method: "POST",
-        body: { fullName: nextName, email: user.email || emailInput.value.trim() },
-      });
-      msg.style.color = "var(--fs-muted)";
-      msg.textContent = "Saved.";
-    } catch (err) {
-      console.error("Failed to update profile:", err);
-      msg.style.color = "var(--red-action-2)";
-      msg.textContent = err.message || "Failed to save.";
-    } finally {
-      hideLoading?.();
+    setMessage("Changes pending…");
+    scheduleProfileSave();
+  });
+
+  nameInput.addEventListener("blur", () => {
+    if (isHydratingProfile) return;
+    if (saveTimer) {
+      window.clearTimeout(saveTimer);
+      saveTimer = null;
     }
+    void persistProfile();
+  });
+
+  reportEmailsCheckbox.addEventListener("change", () => {
+    if (isHydratingProfile) return;
+    if (saveTimer) {
+      window.clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    void persistProfile();
   });
 
   resetBtn.addEventListener("click", async () => {
@@ -295,56 +493,28 @@ export async function renderAccount({ root, auth, db, showLoading, hideLoading }
   async function loadProfile() {
     const token = await user.getIdToken();
     const data = await fetchJson(`/api/data/${encodeURIComponent(user.uid)}?t=${Date.now()}`, { token });
+    isHydratingProfile = true;
     nameInput.value = data.fullName || data.name || data.displayName || user.displayName || "";
     emailInput.value = data.email || user.email || "";
+    reportEmailsCheckbox.checked = getReportEmailPreference(data) ?? false;
     identifierText.textContent = data.identifier ? `User ID: ${data.identifier}` : "";
+    lastSavedProfileState = currentProfileState();
+    isHydratingProfile = false;
+    return data;
   }
 
   // Load brigades list + allow leaving (async; don't block route transition).
   void (async () => {
     try {
-      await loadProfile();
+      const profileData = await loadProfile();
       const brigades = await getUserBrigades({ db, uid: user.uid, force: true });
-      brigadeList.innerHTML = "";
-
-      if (brigades.length === 0) {
-        renderEmptyBrigades();
-        return;
-      }
-
-      brigades.forEach((b) => {
-        const displayRole = roleLabel(b.role);
-        const row = el("div", "fs-row");
-        const left = el("div");
-        const brigadeIdentifier = b.brigadeIdentifier ? `Brigade ID: ${b.brigadeIdentifier}` : "";
-        left.innerHTML = `
-          <div class="fs-row-title">${b.brigadeName || b.id}</div>
-          <div class="fs-row-meta">Role: ${displayRole}</div>
-          ${brigadeIdentifier ? `<div class="fs-row-meta fs-row-meta-subtle">${brigadeIdentifier}</div>` : ""}
-        `;
-        const right = el("div");
-        const pill = el("span", `fs-pill ${isAdminRole(b.role) ? "fs-pill-success" : ""}`);
-        pill.textContent = displayRole;
-
-        const menuBtn = el("button", "fs-icon-btn");
-        menuBtn.type = "button";
-        menuBtn.textContent = "⋯";
-        menuBtn.setAttribute("aria-label", "More actions");
-
-        right.style.display = "flex";
-        right.style.gap = "8px";
-        right.style.alignItems = "center";
-        right.appendChild(pill);
-        right.appendChild(menuBtn);
-
-        menuBtn.addEventListener("click", () => {
-          openActionSheet({ ...b, row });
-        });
-
-        row.appendChild(left);
-        row.appendChild(right);
-        brigadeList.appendChild(row);
-      });
+      const reportEmailsPreference = getReportEmailPreference(profileData);
+      isHydratingProfile = true;
+      reportEmailsCheckbox.checked =
+        reportEmailsPreference !== null ? reportEmailsPreference : brigadesGrantReportEmailsByDefault(brigades);
+      lastSavedProfileState = currentProfileState();
+      isHydratingProfile = false;
+      await refreshBrigadesList({ force: true });
     } catch (err) {
       console.error("Failed to load brigades (account):", err);
       identifierText.textContent = "";

--- a/public/js/app-shell/screens/checks.js
+++ b/public/js/app-shell/screens/checks.js
@@ -81,6 +81,34 @@ function lockOwnerText(lock) {
   return lock?.user || lock?.name || lock?.email || "another member";
 }
 
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatDateTime(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return dateTimeFormatter.format(date);
+}
+
+function lockStartedAt(lockResponse) {
+  return lockResponse?.timestamp || lockResponse?.lock?.timestamp || "";
+}
+
+function sessionStartedBy(session, lock) {
+  return session?.startedByName || session?.startedBy || lockOwnerText(lock);
+}
+
+function sessionStartedAt(session, lock) {
+  return session?.startedAt || lockStartedAt(lock);
+}
+
+function sessionLastEditedAt(session) {
+  return session?.lastSavedAt || session?.updatedAt || session?.editedAt || "";
+}
+
 export async function renderChecks({ root, auth, db, showLoading, hideLoading }) {
   root.innerHTML = "";
 
@@ -173,6 +201,13 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
   modalTitle.textContent = "Check Already in Progress";
   const modalText = el("p");
   modalText.style.color = "var(--fs-muted)";
+  const modalDetails = el("div");
+  modalDetails.style.display = "grid";
+  modalDetails.style.gap = "10px";
+  modalDetails.style.textAlign = "left";
+  const modalDetailsTitle = el("div", "fs-label");
+  modalDetailsTitle.textContent = "Details";
+  modalDetails.appendChild(modalDetailsTitle);
   const resumeBtn = el("button", "fs-btn fs-btn-primary");
   resumeBtn.type = "button";
   resumeBtn.textContent = "Resume Check";
@@ -190,6 +225,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
 
   modalInner.appendChild(modalTitle);
   modalInner.appendChild(modalText);
+  modalInner.appendChild(modalDetails);
   modalInner.appendChild(modalButtons);
   modal.appendChild(modalInner);
   modalOverlay.appendChild(modal);
@@ -203,6 +239,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
   if (!user) return;
 
   let brigadeMetaById = new Map();
+  let activeModalToken = 0;
   function setAlert(el, message) {
     el.textContent = message || "";
     el.style.display = message ? "block" : "none";
@@ -299,20 +336,68 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
               return result;
             };
 
-            const showLockModal = (lockResponse) => {
+            const renderLockDetails = (lockResponse, session) => {
+              const lock = lockResponse?.lock || lockResponse?.checkStatus || lockResponse || {};
+              const startedBy = sessionStartedBy(session, lock);
+              const startedAt = formatDateTime(sessionStartedAt(session, lock));
+              const lastEditedAt = formatDateTime(sessionLastEditedAt(session));
+              modalDetails.replaceChildren(modalDetailsTitle);
+
+              const rows = [
+                { label: "Started by", value: startedBy },
+                { label: "Started", value: startedAt },
+              ];
+              if (lastEditedAt) rows.push({ label: "Last edited", value: lastEditedAt });
+
+              rows.forEach((entry) => {
+                const row = el("div");
+                row.style.display = "grid";
+                row.style.gap = "2px";
+                const rowLabel = el("div", "fs-row-meta");
+                rowLabel.textContent = entry.label;
+                const rowValue = el("div");
+                rowValue.textContent = entry.value || "Not available";
+                row.appendChild(rowLabel);
+                row.appendChild(rowValue);
+                modalDetails.appendChild(row);
+              });
+            };
+
+            const showLockModal = async (lockResponse) => {
               preserveCheckSessionId(lockResponse);
-              const lock = lockResponse?.lock || lockResponse?.checkStatus || lockResponse;
+              const lock = lockResponse?.lock || lockResponse?.checkStatus || lockResponse || {};
+              const modalToken = ++activeModalToken;
               hideLoading?.();
-              modalText.textContent = `A check for this appliance was already started by ${lockOwnerText(lock)}. Would you like to resume or start a new check?`;
+              modalText.textContent = "Resume the existing check or start a new one.";
+              renderLockDetails(lockResponse, null);
               modalOverlay.classList.remove("hidden");
 
+              if (lockResponse?.sessionId) {
+                void (async () => {
+                  try {
+                    const tokenForSession = await user.getIdToken();
+                    const sessionResponse = await fetchJson(
+                      `/api/brigades/${encodeURIComponent(brigadeId)}/check-sessions/${encodeURIComponent(lockResponse.sessionId)}`,
+                      { token: tokenForSession }
+                    );
+                    if (modalToken !== activeModalToken || modalOverlay.classList.contains("hidden")) return;
+                    renderLockDetails(lockResponse, sessionResponse?.session || sessionResponse);
+                  } catch (err) {
+                    if (modalToken !== activeModalToken) return;
+                    console.warn("Unable to load check session details:", err);
+                  }
+                })();
+              }
+
               resumeBtn.onclick = () => {
+                activeModalToken += 1;
                 modalOverlay.classList.add("hidden");
                 showLoading?.();
                 openCheckForm();
               };
 
               startNewBtn.onclick = async () => {
+                activeModalToken += 1;
                 modalOverlay.classList.add("hidden");
                 showLoading?.();
                 try {
@@ -333,7 +418,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
             };
 
             if (status?.inProgress) {
-              showLockModal(status);
+              await showLockModal(status);
               return;
             }
 
@@ -341,7 +426,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
               await startCheck();
             } catch (err) {
               if (err.status === 409 || err.code === "CHECK_LOCKED") {
-                showLockModal(err.data);
+                await showLockModal(err.data);
                 return;
               }
               throw err;


### PR DESCRIPTION
## What changed
- added account autosave for full name and report email preferences
- added check-in-progress modal details for started by, started time, and last edited time
- added report email preference handling and unsubscribe support in the backend

## Why
- users asked for simpler profile editing and clearer check ownership details
- report emails now need explicit preference handling with sensible defaults by role

## Impact
- account changes save automatically instead of using a profile save button
- gear managers and admins receive report emails by default; others can opt in
- report notification emails include an unsubscribe link

## Validation
- node --check functions/index.js
- node --check public/js/app-shell/screens/account.js
- node --check public/js/app-shell/screens/checks.js
- git diff --check
