### PR TITLE
[codex] Use inline loading for check route startup

### DIFF
--- a/public/checks.html
+++ b/public/checks.html
@@ -33,6 +33,12 @@
             height: 100%;
             object-fit: cover; /* Ensure image covers the box */
         }
+        .item-box.status-present > img,
+        .item-box.status-missing > img,
+        .item-box.status-note > img,
+        .item-box.status-partial > img {
+            opacity: 0.35;
+        }
         .item-box:hover { background-color: #d1d5db; }
         .item-box.is-active { 
             border: 4px solid #180F5E; /* Blue */

--- a/public/js/app-shell/app-shell.js
+++ b/public/js/app-shell/app-shell.js
@@ -212,16 +212,32 @@ function renderTermsGate({ user, userData, loadError, onAccepted }) {
   });
 }
 
+function renderStartupStatus(message) {
+  setShellChromeVisible(true);
+  appRoot.innerHTML = `
+    <section class="fs-page max-w-md mx-auto">
+      <div class="fs-card">
+        <div class="fs-card-inner">
+          <div class="fs-row">
+            <div>
+              <div class="fs-row-title">${message || "Loading..."}</div>
+              <div class="fs-row-meta">Preparing your Flashover session</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  `;
+}
+
 async function ensureTermsAccepted(user) {
   let userData = null;
   let loadError = null;
+  renderStartupStatus("Loading account...");
   try {
-    showLoading();
     userData = await fetchUserProfile(user);
   } catch (err) {
     loadError = err;
-  } finally {
-    hideLoading();
   }
 
   if (hasAcceptedTerms(userData)) return true;

--- a/public/js/app-shell/screens/check.js
+++ b/public/js/app-shell/screens/check.js
@@ -161,7 +161,7 @@ const CHECK_SCREEN_MARKUP = `
         <img src="/design_assets/Back Icon.png" alt="Back" class="h-8 w-8">
       </button>
     </div>
-    <h1 id="header-title" class="text-white text-2xl font-bold flex-grow text-center">Locker Name</h1>
+    <h1 id="header-title" class="text-white text-2xl font-bold flex-grow text-center">Loading check</h1>
     <div class="w-20 flex justify-end">
       <button id="go-to-locker-status-btn">
         <img src="/design_assets/Truck Icon White.png" alt="Locker Status" class="h-10 w-10">
@@ -180,8 +180,8 @@ const CHECK_SCREEN_MARKUP = `
               </div>
             </div>
             <div class="col-span-1 md:col-span-2 bg-blue rounded-lg shadow-[0_4px_8px_3px_rgba(0,0,0,0.25)] p-4 flex flex-col text-white">
-              <h2 id="item-name" class="text-2xl font-bold mb-2">Item Name</h2>
-              <p id="item-desc" class="text-base whitespace-pre-wrap flex-grow overflow-y-auto">Item description.</p>
+              <h2 id="item-name" class="text-2xl font-bold mb-2">Preparing items</h2>
+              <p id="item-desc" class="text-base whitespace-pre-wrap flex-grow overflow-y-auto">Fetching appliance setup and saved progress.</p>
             </div>
           </div>
         </div>
@@ -191,7 +191,7 @@ const CHECK_SCREEN_MARKUP = `
         <div class="bg-blue rounded-lg p-4 flex flex-col gap-4 min-h-full">
           <div class="flex items-center justify-center mb-4 flex-shrink-0">
             <div class="text-center">
-              <h2 id="locker-editor-name" class="text-white text-2xl font-bold uppercase tracking-wider">Locker Name</h2>
+              <h2 id="locker-editor-name" class="text-white text-2xl font-bold uppercase tracking-wider">Loading check</h2>
               <p id="locker-context-label" class="hidden text-sm font-semibold text-blue-100 mt-1">Inside container</p>
             </div>
           </div>

--- a/public/js/app-shell/screens/check.js
+++ b/public/js/app-shell/screens/check.js
@@ -29,6 +29,12 @@ const CHECK_SCREEN_STYLES = `
   height: 100%;
   object-fit: cover;
 }
+#shell-check-wrapper .item-box.status-present > img,
+#shell-check-wrapper .item-box.status-missing > img,
+#shell-check-wrapper .item-box.status-note > img,
+#shell-check-wrapper .item-box.status-partial > img {
+  opacity: 0.35;
+}
 #shell-check-wrapper .item-box:hover { background-color: #d1d5db; }
 #shell-check-wrapper .item-box.is-active {
   border: 4px solid #180F5E;

--- a/public/js/app-shell/screens/checks.js
+++ b/public/js/app-shell/screens/checks.js
@@ -292,6 +292,15 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
           appliance.name || "Unnamed appliance",
           canStartChecks ? "Tap to start" : "View only"
         );
+        const rowMeta = text.querySelector(".fs-row-meta");
+        const defaultMeta = rowMeta ? rowMeta.textContent : "";
+        let rowBusy = false;
+        const setRowBusy = (busy, message) => {
+          rowBusy = busy;
+          row.disabled = busy || !canStartChecks;
+          row.setAttribute("aria-busy", busy ? "true" : "false");
+          if (rowMeta) rowMeta.textContent = busy ? message : defaultMeta;
+        };
 
         left.appendChild(bubble);
         left.appendChild(text);
@@ -308,10 +317,10 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
         row.title = canStartChecks ? "" : "Viewers cannot start or resume checks.";
 
         row.addEventListener("click", async () => {
-          if (!canStartChecks) return;
+          if (!canStartChecks || rowBusy) return;
           setAlert(errorEl, "");
           setAlert(successEl, "");
-          showLoading?.();
+          setRowBusy(true, "Checking status...");
           try {
             const token = await user.getIdToken();
             const status = await fetchJson(
@@ -328,6 +337,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
             };
 
             const startCheck = async ({ force = false } = {}) => {
+              setRowBusy(true, force ? "Starting new check..." : "Starting check...");
               const result = await fetchJson(
                 `/api/brigades/${encodeURIComponent(brigadeId)}/appliances/${encodeURIComponent(appliance.id)}/start-check`,
                 { token, method: "POST", body: force ? { force: true } : undefined }
@@ -392,7 +402,6 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
               resumeBtn.onclick = () => {
                 activeModalToken += 1;
                 modalOverlay.classList.add("hidden");
-                showLoading?.();
                 openCheckForm();
               };
 
@@ -437,6 +446,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
             setAlert(errorEl, err.message);
           } finally {
             hideLoading?.();
+            setRowBusy(false);
           }
         });
 

--- a/public/js/app-shell/screens/checks.js
+++ b/public/js/app-shell/screens/checks.js
@@ -33,6 +33,11 @@ function clearCheckSession() {
   sessionStorage.removeItem("currentCheckState");
 }
 
+function setCheckSessionStartupMode(mode) {
+  if (mode) localStorage.setItem("checkSessionStartupMode", mode);
+  else localStorage.removeItem("checkSessionStartupMode");
+}
+
 function normalizeRole(role) {
   const raw = String(role || "").trim().toLowerCase().replace(/[\s_-]+/g, "");
   if (raw === "admin") return "admin";
@@ -343,6 +348,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
                 { token, method: "POST", body: force ? { force: true } : undefined }
               );
               preserveCheckSessionId(result);
+              setCheckSessionStartupMode("new");
               return result;
             };
 
@@ -402,6 +408,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
               resumeBtn.onclick = () => {
                 activeModalToken += 1;
                 modalOverlay.classList.add("hidden");
+                setCheckSessionStartupMode("resume");
                 openCheckForm();
               };
 

--- a/public/js/app-shell/screens/checks.js
+++ b/public/js/app-shell/screens/checks.js
@@ -408,7 +408,6 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
               startNewBtn.onclick = async () => {
                 activeModalToken += 1;
                 modalOverlay.classList.add("hidden");
-                showLoading?.();
                 try {
                   await startCheck({ force: true });
                   clearCheckSession();
@@ -421,7 +420,7 @@ export async function renderChecks({ root, auth, db, showLoading, hideLoading })
                   console.error("Error starting new check:", err);
                   setAlert(errorEl, err.message);
                 } finally {
-                  hideLoading?.();
+                  setRowBusy(false);
                 }
               };
             };

--- a/public/js/checks.js
+++ b/public/js/checks.js
@@ -112,8 +112,10 @@ function initChecksPage(options = {}) {
     const CHECK_SESSION_ID_KEY = 'checkSessionId';
     const CHECK_SESSION_BRIGADE_ID_KEY = 'checkSessionBrigadeId';
     const CHECK_SESSION_APPLIANCE_ID_KEY = 'checkSessionApplianceId';
+    let isInitialShellLoad = isShell;
 
     function showLoading() {
+        if (isInitialShellLoad) return;
         if (loadingOverlay) loadingOverlay.style.display = 'flex';
     }
 
@@ -1964,12 +1966,17 @@ function initChecksPage(options = {}) {
         unsubscribeAuth = auth.onAuthStateChanged(async (user) => {
             if (user) {
                 currentUser = user;
-                setupEventListeners();
-                loadStateFromSession();
-                await loadData();
-                await loadCheckSessionFromServer();
-                startOrResumeChecks();
+                try {
+                    setupEventListeners();
+                    loadStateFromSession();
+                    await loadData();
+                    await loadCheckSessionFromServer();
+                    startOrResumeChecks();
+                } finally {
+                    isInitialShellLoad = false;
+                }
             } else {
+                isInitialShellLoad = false;
                 goToSignIn();
             }
         });

--- a/public/js/checks.js
+++ b/public/js/checks.js
@@ -101,6 +101,17 @@ function initChecksPage(options = {}) {
             });
     }
 
+    function appendItemThumbnail(itemBox, item) {
+        const imageRef = item && item.img ? item.img : '';
+        if (!itemBox || !imageRef) return;
+        const img = document.createElement('img');
+        img.alt = '';
+        img.loading = 'lazy';
+        img.decoding = 'async';
+        itemBox.appendChild(img);
+        setImageElementSource(img, imageRef, '/design_assets/Flashover Logo.png');
+    }
+
     // ===================================================================
     // JAVASCRIPT - THE BRAIN OF THE APP
     // ===================================================================
@@ -112,6 +123,7 @@ function initChecksPage(options = {}) {
     const CHECK_SESSION_ID_KEY = 'checkSessionId';
     const CHECK_SESSION_BRIGADE_ID_KEY = 'checkSessionBrigadeId';
     const CHECK_SESSION_APPLIANCE_ID_KEY = 'checkSessionApplianceId';
+    const CHECK_SESSION_STARTUP_MODE_KEY = 'checkSessionStartupMode';
     let isInitialShellLoad = isShell;
 
     function showLoading() {
@@ -969,7 +981,9 @@ function initChecksPage(options = {}) {
         }
 
         activeCheckSessionId = sessionId;
-        setSaveStatus('saved', 'Resuming saved check...');
+        const startupMode = String(localStorage.getItem(CHECK_SESSION_STARTUP_MODE_KEY) || '').trim();
+        localStorage.removeItem(CHECK_SESSION_STARTUP_MODE_KEY);
+        setSaveStatus('saved', startupMode === 'new' ? 'Starting new check...' : 'Resuming saved check...');
         try {
             const baseUrl = checkSessionBaseUrl();
             const claimed = await fetchApiJson(`${baseUrl}/claim`, { method: 'POST' });
@@ -1186,6 +1200,7 @@ function initChecksPage(options = {}) {
                 itemBox.classList.add(`status-${result.status}`);
             }
             itemBox.dataset.id = item.id;
+            appendItemThumbnail(itemBox, item);
             const overlay = document.createElement('div');
             overlay.className = 'item-name-overlay';
             overlay.textContent = item.name || 'Item';
@@ -1321,6 +1336,7 @@ function initChecksPage(options = {}) {
             }
             itemBox.dataset.id = item.id;
             itemBox.dataset.parentId = container.id;
+            appendItemThumbnail(itemBox, item);
             const overlay = document.createElement('div');
             overlay.className = 'item-name-overlay';
             overlay.textContent = item.name || 'Item';


### PR DESCRIPTION
## Summary
- replace the full-screen spinner on appliance check startup with inline row progress text
- suppress the legacy full-screen checks loader during the initial app-shell check route hydration
- update the check route placeholders so the native shell shows meaningful startup copy while data loads

## Why
Moving from `/#/checks` into `/#/check/:brigadeId/:applianceId` currently chains check-status/start-check calls, check script loading, brigade data loading, and optional session resume calls behind the global loading overlay. That makes the transition feel like a full-screen block even though the check screen can be painted immediately.

## Validation
- `git diff --check`
- `node --check public/js/checks.js`
- `node --check public/js/app-shell/screens/checks.js`
- `node --check public/js/app-shell/screens/check.js`
