### PR TITLE
Constrain setup item image preview

### DIFF
--- a/public/js/app-shell/screens/setup-editor.js
+++ b/public/js/app-shell/screens/setup-editor.js
@@ -251,7 +251,7 @@ const SETUP_EDITOR_STYLES = `
   gap: 14px;
 }
 .fs-setup-image-picker {
-  min-height: 150px;
+  height: 150px;
   border: 2px dashed rgba(37, 99, 235, 0.3);
   border-radius: 16px;
   background: rgba(15, 23, 42, 0.03);
@@ -304,6 +304,9 @@ const SETUP_EDITOR_STYLES = `
   }
   .fs-setup-field-grid {
     grid-template-columns: 1fr;
+  }
+  .fs-setup-image-picker {
+    height: 118px;
   }
 }
 `;


### PR DESCRIPTION
## Summary
- stop item edit images from expanding the setup modal to their natural height
- keep the image preview fixed at 150px on larger screens and 118px on mobile

## Checks
- node --check public/js/app-shell/screens/setup-editor.js
- git diff --check