### PR TITLE
[codex] Add report actions menu

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -128,6 +128,11 @@ function canViewReports(role) {
     return !!normalizeRole(role);
 }
 
+function canManageReports(role) {
+    const normalized = normalizeRole(role);
+    return normalized === ROLES.ADMIN || normalized === ROLES.GEAR_MANAGER;
+}
+
 function defaultReportEmailsEnabled(role) {
     const normalized = normalizeRole(role);
     return normalized === ROLES.ADMIN || normalized === ROLES.GEAR_MANAGER;
@@ -334,6 +339,43 @@ function isLegacyProjectStorageUrl(value) {
         return false;
     }
     return false;
+}
+
+function collectReportNoteImageRefs(brigadeId, reportData) {
+    const refs = new Set();
+    const addRef = (value) => {
+        const ref = normalizeUploadStoragePath(brigadeId, value);
+        if (ref) refs.add(ref);
+    };
+    const visitItem = (item) => {
+        if (!item || typeof item !== 'object') return;
+        addRef(item.noteImage);
+        if (Array.isArray(item.subItems)) {
+            item.subItems.forEach(visitItem);
+        }
+    };
+
+    const lockers = Array.isArray(reportData && reportData.lockers) ? reportData.lockers : [];
+    lockers.forEach((locker) => {
+        const items = Array.isArray(locker && locker.items)
+            ? locker.items
+            : (Array.isArray(locker && locker.shelves)
+                ? locker.shelves.flatMap((shelf) => Array.isArray(shelf && shelf.items) ? shelf.items : [])
+                : []);
+        items.forEach(visitItem);
+    });
+    return Array.from(refs);
+}
+
+async function deleteReportStorageImages(imageRefs) {
+    await Promise.all((Array.isArray(imageRefs) ? imageRefs : []).map(async (imageRef) => {
+        try {
+            await bucket.file(imageRef).delete();
+        } catch (error) {
+            if (error && error.code === 404) return;
+            throw error;
+        }
+    }));
 }
 
 function normalizeImageRef(brigadeId, value, existingValue = '') {
@@ -2066,6 +2108,90 @@ brigadeRouter.get('/:brigadeId/reports/:reportId', async (req, res) => {
         res.status(500).json({ message: 'Failed to fetch report.' });
     }
 });
+
+brigadeRouter.get('/:brigadeId/reports/:reportId/export.pdf', async (req, res) => {
+    try {
+        const { brigadeId, reportId } = req.params;
+        const userId = req.user.uid;
+        const memberRef = db.collection('brigades').doc(brigadeId).collection('members').doc(userId);
+        const memberDoc = await memberRef.get();
+        if (!memberDoc.exists) {
+            return res.status(403).json({ message: 'Forbidden: You are not a member of this brigade.' });
+        }
+
+        const brigade = await getBrigadeDoc(brigadeId);
+        if (!brigade) {
+            return res.status(404).json({ message: 'Brigade not found.' });
+        }
+
+        const reportRef = brigade.ref.collection('reports').doc(reportId);
+        const reportDoc = await reportRef.get();
+        if (!reportDoc.exists) {
+            return res.status(404).json({ message: 'Report not found.' });
+        }
+
+        const reportData = { id: reportDoc.id, ...(reportDoc.data() || {}) };
+        const reportDate = parseReportDateMs(reportData.date) != null ? new Date(reportData.date) : new Date();
+        const payload = {
+            brigadeId,
+            brigadeName: brigade.data && brigade.data.name,
+            applianceId: reportData.applianceId || '',
+            applianceName: reportData.applianceName || 'Appliance',
+            from: reportDate,
+            to: reportDate,
+            reports: [reportData],
+        };
+        const pdfBuffer = await buildReportExportPdf(payload);
+        const filename = buildReportExportFilename(payload);
+
+        setPdfDownloadHeaders(res, filename, pdfBuffer.length);
+        res.status(200).send(pdfBuffer);
+    } catch (error) {
+        console.error(`Error exporting report ${req.params.reportId}:`, error);
+        res.status(500).json({ message: 'Failed to export report.' });
+    }
+});
+
+brigadeRouter.delete('/:brigadeId/reports/:reportId', async (req, res) => {
+    try {
+        const { brigadeId, reportId } = req.params;
+        const userId = req.user.uid;
+        const memberRef = db.collection('brigades').doc(brigadeId).collection('members').doc(userId);
+        const memberDoc = await memberRef.get();
+        if (!memberDoc.exists) {
+            return res.status(403).json({ message: 'Forbidden: You are not a member of this brigade.' });
+        }
+        if (!canManageReports(memberDoc.data().role)) {
+            return res.status(403).json({ message: 'Forbidden: Admin or Gear Manager role required to delete reports.' });
+        }
+
+        const brigadeRef = db.collection('brigades').doc(brigadeId);
+        const brigadeDoc = await brigadeRef.get();
+        if (!brigadeDoc.exists) {
+            return res.status(404).json({ message: 'Brigade not found.' });
+        }
+
+        const reportRef = brigadeRef.collection('reports').doc(reportId);
+        const reportDoc = await reportRef.get();
+        if (!reportDoc.exists) {
+            return res.status(404).json({ message: 'Report not found.' });
+        }
+
+        const imageRefs = collectReportNoteImageRefs(brigadeId, reportDoc.data() || {});
+        await deleteReportStorageImages(imageRefs);
+
+        const batch = db.batch();
+        batch.delete(reportRef.collection('meta').doc('signoff'));
+        batch.delete(reportRef);
+        await batch.commit();
+
+        res.status(200).json({ message: 'Report deleted successfully.' });
+    } catch (error) {
+        console.error(`Error deleting report ${req.params.reportId}:`, error);
+        res.status(500).json({ message: 'Failed to delete report.' });
+    }
+});
+
 brigadeRouter.post('/:brigadeId/data', async (req, res) => {
     try {
         const { brigadeId } = req.params;

--- a/public/js/app-shell/app-shell.js
+++ b/public/js/app-shell/app-shell.js
@@ -428,6 +428,7 @@ const routes = {
     await renderReport({
       root: appRoot,
       auth,
+      db,
       brigadeId: params.brigadeId,
       reportId: params.reportId,
       setTitle: (t) => setHeader({ title: t, showBack: true, showLogout: false }),

--- a/public/js/app-shell/screens/report.js
+++ b/public/js/app-shell/screens/report.js
@@ -1,3 +1,5 @@
+import { getUserBrigades } from "../cache.js";
+
 function el(tag, className) {
   const node = document.createElement(tag);
   if (className) node.className = className;
@@ -32,6 +34,55 @@ const statusIcons = {
 
 function isPrivateImageRef(value) {
   return typeof value === "string" && /^uploads\/[^/]+\/image-[A-Za-z0-9._-]+\.webp$/.test(value);
+}
+
+function normalizeRole(role) {
+  const raw = String(role || "").trim().toLowerCase().replace(/[\s_-]+/g, "");
+  if (raw === "admin") return "admin";
+  if (raw === "gearmanager") return "gearManager";
+  if (raw === "member") return "member";
+  if (raw === "viewer") return "viewer";
+  return null;
+}
+
+function canManageReports(role) {
+  const normalized = normalizeRole(role);
+  return normalized === "admin" || normalized === "gearManager";
+}
+
+function filenameFromContentDisposition(header) {
+  const value = String(header || "");
+  const encoded = value.match(/filename\*=UTF-8''([^;]+)/i);
+  if (encoded) {
+    try {
+      return decodeURIComponent(encoded[1]);
+    } catch (e) {
+      return "";
+    }
+  }
+  const quoted = value.match(/filename="([^"]+)"/i);
+  return quoted ? quoted[1] : "";
+}
+
+async function downloadReportPdf({ brigadeId, reportId, token, fallbackFilename }) {
+  const response = await fetch(
+    `/api/brigades/${encodeURIComponent(brigadeId)}/reports/${encodeURIComponent(reportId)}/export.pdf`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.message || `Request failed (${response.status})`);
+  }
+
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filenameFromContentDisposition(response.headers.get("Content-Disposition")) || fallbackFilename || "flashover-report.pdf";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 function drawSignatureOnCanvas(canvas, signature) {
@@ -216,6 +267,7 @@ function renderItem(
 export async function renderReport({
   root,
   auth,
+  db,
   brigadeId,
   reportId,
   setTitle,
@@ -232,12 +284,24 @@ export async function renderReport({
 
   const metaCard = el("div", "fs-card");
   const metaInner = el("div", "fs-card-inner fs-stack");
+  const metaHeader = el("div");
+  metaHeader.style.display = "flex";
+  metaHeader.style.alignItems = "flex-start";
+  metaHeader.style.justifyContent = "space-between";
+  metaHeader.style.gap = "12px";
   const metaTitle = el("div");
   metaTitle.innerHTML = `<div class="fs-card-title">Report details</div><div class="fs-card-subtitle">Who completed this check and when.</div>`;
+  const actionsMenu = el("button", "fs-icon-btn");
+  actionsMenu.type = "button";
+  actionsMenu.textContent = "⋯";
+  actionsMenu.setAttribute("aria-label", "More actions");
+  actionsMenu.disabled = true;
+  metaHeader.appendChild(metaTitle);
+  metaHeader.appendChild(actionsMenu);
   const metaBy = el("div", "fs-row-meta");
   const metaByApp = el("div", "fs-row-meta fs-row-meta-subtle");
   const metaDate = el("div", "fs-row-meta");
-  metaInner.appendChild(metaTitle);
+  metaInner.appendChild(metaHeader);
   metaInner.appendChild(metaBy);
   metaInner.appendChild(metaByApp);
   metaInner.appendChild(metaDate);
@@ -296,10 +360,103 @@ export async function renderReport({
   const user = auth?.currentUser;
   if (!user) return;
 
+  document.getElementById("report-detail-action-sheet")?.remove();
+  const actionSheet = el("div", "fs-sheet-backdrop hidden");
+  actionSheet.id = "report-detail-action-sheet";
+  const sheet = el("div", "fs-sheet");
+  const sheetTitle = el("div", "fs-sheet-title");
+  sheetTitle.textContent = "Report actions";
+  const sheetSubtitle = el("div", "fs-row-meta");
+  const sheetActions = el("div", "fs-sheet-actions");
+  const sheetDownload = el("button", "fs-btn fs-btn-secondary");
+  sheetDownload.type = "button";
+  sheetDownload.textContent = "Download report";
+  const sheetDelete = el("button", "fs-btn fs-btn-danger");
+  sheetDelete.type = "button";
+  sheetDelete.textContent = "Delete report";
+  const sheetCancel = el("button", "fs-btn fs-btn-secondary");
+  sheetCancel.type = "button";
+  sheetCancel.textContent = "Cancel";
+  sheetActions.appendChild(sheetDownload);
+  sheetActions.appendChild(sheetDelete);
+  sheetActions.appendChild(sheetCancel);
+  sheet.appendChild(sheetTitle);
+  sheet.appendChild(sheetSubtitle);
+  sheet.appendChild(sheetActions);
+  actionSheet.appendChild(sheet);
+  document.body.appendChild(actionSheet);
+
+  let currentReport = null;
+  let canDeleteReport = false;
+
   function setAlert(el, message) {
     el.textContent = message || "";
     el.style.display = message ? "block" : "none";
   }
+
+  function openActionSheet() {
+    if (!currentReport) return;
+    sheetSubtitle.textContent = currentReport.applianceName || "Report";
+    sheetDelete.style.display = canDeleteReport ? "" : "none";
+    actionSheet.classList.remove("hidden");
+  }
+
+  function closeActionSheet() {
+    actionSheet.classList.add("hidden");
+  }
+
+  sheet.addEventListener("click", (e) => {
+    e.stopPropagation();
+  });
+
+  actionSheet.addEventListener("click", (e) => {
+    if (e.target === actionSheet) closeActionSheet();
+  });
+
+  actionsMenu.addEventListener("click", openActionSheet);
+  sheetCancel.addEventListener("click", closeActionSheet);
+
+  sheetDownload.addEventListener("click", async () => {
+    if (!currentReport) return;
+    closeActionSheet();
+    setAlert(errorEl, "");
+    showLoading?.();
+    try {
+      const token = await user.getIdToken();
+      await downloadReportPdf({
+        brigadeId,
+        reportId,
+        token,
+        fallbackFilename: `${currentReport.applianceName || "flashover-report"}.pdf`,
+      });
+    } catch (err) {
+      console.error("Failed to download report:", err);
+      setAlert(errorEl, err.message || "Could not download the report.");
+    } finally {
+      hideLoading?.();
+    }
+  });
+
+  sheetDelete.addEventListener("click", async () => {
+    if (!currentReport || !canDeleteReport) return;
+    if (!confirm("Are you sure you want to delete this report? This cannot be undone.")) return;
+    closeActionSheet();
+    setAlert(errorEl, "");
+    showLoading?.();
+    try {
+      const token = await user.getIdToken();
+      await fetchJson(
+        `/api/brigades/${encodeURIComponent(brigadeId)}/reports/${encodeURIComponent(reportId)}`,
+        { token, method: "DELETE" }
+      );
+      window.location.hash = "#/reports";
+    } catch (err) {
+      console.error("Failed to delete report:", err);
+      setAlert(errorEl, err.message || "Could not delete the report.");
+    } finally {
+      hideLoading?.();
+    }
+  });
 
   let searchEntries = [];
   let flashTimer = null;
@@ -444,10 +601,17 @@ export async function renderReport({
         noteImageUrlCache.set(imageRef, url);
         return url;
       }
-      const report = await fetchJson(
-        `/api/brigades/${encodeURIComponent(brigadeId)}/reports/${encodeURIComponent(reportId)}`,
-        { token }
-      );
+      const [report, brigades] = await Promise.all([
+        fetchJson(
+          `/api/brigades/${encodeURIComponent(brigadeId)}/reports/${encodeURIComponent(reportId)}`,
+          { token }
+        ),
+        db ? getUserBrigades({ db, uid: user.uid }).catch(() => []) : Promise.resolve([]),
+      ]);
+      currentReport = report;
+      const activeBrigade = Array.isArray(brigades) ? brigades.find((b) => b.id === brigadeId) : null;
+      canDeleteReport = canManageReports(activeBrigade?.role);
+      actionsMenu.disabled = false;
 
       const title = `Report for ${report.applianceName || "Appliance"}`;
       setTitle?.(title);

--- a/public/js/app-shell/screens/reports.js
+++ b/public/js/app-shell/screens/reports.js
@@ -52,6 +52,55 @@ function buildReportExportHandoffUrl(pdfUrl) {
   return url.toString();
 }
 
+function normalizeRole(role) {
+  const raw = String(role || "").trim().toLowerCase().replace(/[\s_-]+/g, "");
+  if (raw === "admin") return "admin";
+  if (raw === "gearmanager") return "gearManager";
+  if (raw === "member") return "member";
+  if (raw === "viewer") return "viewer";
+  return null;
+}
+
+function canManageReports(role) {
+  const normalized = normalizeRole(role);
+  return normalized === "admin" || normalized === "gearManager";
+}
+
+function filenameFromContentDisposition(header) {
+  const value = String(header || "");
+  const encoded = value.match(/filename\*=UTF-8''([^;]+)/i);
+  if (encoded) {
+    try {
+      return decodeURIComponent(encoded[1]);
+    } catch (e) {
+      return "";
+    }
+  }
+  const quoted = value.match(/filename="([^"]+)"/i);
+  return quoted ? quoted[1] : "";
+}
+
+async function downloadReportPdf({ brigadeId, reportId, token, fallbackFilename }) {
+  const response = await fetch(
+    `/api/brigades/${encodeURIComponent(brigadeId)}/reports/${encodeURIComponent(reportId)}/export.pdf`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.message || `Request failed (${response.status})`);
+  }
+
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filenameFromContentDisposition(response.headers.get("Content-Disposition")) || fallbackFilename || "flashover-report.pdf";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
 export async function renderReports({ root, auth, db, showLoading, hideLoading }) {
   root.innerHTML = "";
 
@@ -179,10 +228,64 @@ export async function renderReports({ root, auth, db, showLoading, hideLoading }
   const user = auth?.currentUser;
   if (!user) return;
 
+  document.getElementById("report-action-sheet")?.remove();
+  const actionSheet = el("div", "fs-sheet-backdrop hidden");
+  actionSheet.id = "report-action-sheet";
+  const sheet = el("div", "fs-sheet");
+  const sheetTitle = el("div", "fs-sheet-title");
+  sheetTitle.textContent = "Report actions";
+  const sheetSubtitle = el("div", "fs-row-meta");
+  const sheetActions = el("div", "fs-sheet-actions");
+  const sheetDownload = el("button", "fs-btn fs-btn-secondary");
+  sheetDownload.type = "button";
+  sheetDownload.textContent = "Download report";
+  const sheetDelete = el("button", "fs-btn fs-btn-danger");
+  sheetDelete.type = "button";
+  sheetDelete.textContent = "Delete report";
+  const sheetCancel = el("button", "fs-btn fs-btn-secondary");
+  sheetCancel.type = "button";
+  sheetCancel.textContent = "Cancel";
+  sheetActions.appendChild(sheetDownload);
+  sheetActions.appendChild(sheetDelete);
+  sheetActions.appendChild(sheetCancel);
+  sheet.appendChild(sheetTitle);
+  sheet.appendChild(sheetSubtitle);
+  sheet.appendChild(sheetActions);
+  actionSheet.appendChild(sheet);
+  document.body.appendChild(actionSheet);
+
+  let actionReport = null;
+  let actionCanDelete = false;
+  let activeBrigade = null;
+
   function setAlert(el, message) {
     el.textContent = message || "";
     el.style.display = message ? "block" : "none";
   }
+
+  function openActionSheet(report, canDelete) {
+    actionReport = report;
+    actionCanDelete = !!canDelete;
+    sheetSubtitle.textContent = report?.applianceName || "Report";
+    sheetDelete.style.display = actionCanDelete ? "" : "none";
+    actionSheet.classList.remove("hidden");
+  }
+
+  function closeActionSheet() {
+    actionSheet.classList.add("hidden");
+    actionReport = null;
+    actionCanDelete = false;
+  }
+
+  sheet.addEventListener("click", (e) => {
+    e.stopPropagation();
+  });
+
+  actionSheet.addEventListener("click", (e) => {
+    if (e.target === actionSheet) closeActionSheet();
+  });
+
+  sheetCancel.addEventListener("click", closeActionSheet);
 
   function setExportLink(message, url) {
     exportSuccessEl.textContent = "";
@@ -332,13 +435,14 @@ export async function renderReports({ root, auth, db, showLoading, hideLoading }
   downloadBtn.addEventListener("click", downloadExport);
   emailBtn.addEventListener("click", emailExport);
 
-  async function loadReportsForBrigade(brigadeId) {
+  async function loadReportsForBrigade(brigadeId, brigade = null) {
     setAlert(errorEl, "");
     list.innerHTML =
       '<div class="fs-row"><div><div class="fs-row-title">Loading…</div><div class="fs-row-meta">Fetching reports</div></div></div>';
     try {
       const token = await user.getIdToken();
       const reports = await fetchJson(`/api/reports/brigade/${encodeURIComponent(brigadeId)}`, { token });
+      const canDeleteReports = canManageReports(brigade?.role);
 
       list.innerHTML = "";
       if (!Array.isArray(reports) || reports.length === 0) {
@@ -348,8 +452,9 @@ export async function renderReports({ root, auth, db, showLoading, hideLoading }
       }
 
       reports.forEach((report) => {
-        const card = el("button", "fs-row");
-        card.type = "button";
+        const card = el("div", "fs-row");
+        card.setAttribute("role", "button");
+        card.setAttribute("tabindex", "0");
         const appUsername = report.username || report.creatorName || "Unknown";
         const signedName = typeof report.signedName === "string" ? report.signedName.trim() : "";
         const who = signedName || appUsername;
@@ -370,6 +475,16 @@ export async function renderReports({ root, auth, db, showLoading, hideLoading }
           <div class="fs-row-meta fs-row-meta-subtle">app username: ${appUsername}</div>
         `;
 
+        const actions = el("div");
+        actions.style.display = "flex";
+        actions.style.alignItems = "center";
+        actions.style.gap = "8px";
+
+        const menu = el("button", "fs-icon-btn");
+        menu.type = "button";
+        menu.textContent = "⋯";
+        menu.setAttribute("aria-label", "More actions");
+
         const chevron = el("div");
         chevron.style.color = "var(--fs-muted)";
         chevron.style.fontWeight = "900";
@@ -378,11 +493,25 @@ export async function renderReports({ root, auth, db, showLoading, hideLoading }
 
         left.appendChild(bubble);
         left.appendChild(text);
+        actions.appendChild(menu);
+        actions.appendChild(chevron);
         card.appendChild(left);
-        card.appendChild(chevron);
+        card.appendChild(actions);
 
-        card.addEventListener("click", () => {
+        const openReport = () => {
           window.location.hash = `#/report/${encodeURIComponent(brigadeId)}/${encodeURIComponent(report.id)}`;
+        };
+
+        card.addEventListener("click", openReport);
+        card.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            openReport();
+          }
+        });
+        menu.addEventListener("click", (e) => {
+          e.stopPropagation();
+          openActionSheet(report, canDeleteReports);
         });
         list.appendChild(card);
       });
@@ -392,6 +521,50 @@ export async function renderReports({ root, auth, db, showLoading, hideLoading }
       setAlert(errorEl, err.message);
     }
   }
+
+  sheetDownload.addEventListener("click", async () => {
+    const report = actionReport;
+    if (!report) return;
+    closeActionSheet();
+    setAlert(errorEl, "");
+    showLoading?.();
+    try {
+      const token = await user.getIdToken();
+      await downloadReportPdf({
+        brigadeId: select.value,
+        reportId: report.id,
+        token,
+        fallbackFilename: `${report.applianceName || "flashover-report"}.pdf`,
+      });
+    } catch (err) {
+      console.error("Failed to download report:", err);
+      setAlert(errorEl, err.message || "Could not download the report.");
+    } finally {
+      hideLoading?.();
+    }
+  });
+
+  sheetDelete.addEventListener("click", async () => {
+    const report = actionReport;
+    if (!report || !actionCanDelete) return;
+    if (!confirm("Are you sure you want to delete this report? This cannot be undone.")) return;
+    closeActionSheet();
+    setAlert(errorEl, "");
+    showLoading?.();
+    try {
+      const token = await user.getIdToken();
+      await fetchJson(
+        `/api/brigades/${encodeURIComponent(select.value)}/reports/${encodeURIComponent(report.id)}`,
+        { token, method: "DELETE" }
+      );
+      await loadReportsForBrigade(select.value, activeBrigade);
+    } catch (err) {
+      console.error("Failed to delete report:", err);
+      setAlert(errorEl, err.message || "Could not delete the report.");
+    } finally {
+      hideLoading?.();
+    }
+  });
 
   // Don't block route transitions on network reads; render immediately and hydrate async.
   void (async () => {
@@ -417,16 +590,18 @@ export async function renderReports({ root, auth, db, showLoading, hideLoading }
       const active = storedExists ? stored : brigades[0].id;
       localStorage.setItem("activeBrigadeId", active);
       select.value = active;
+      activeBrigade = brigades.find((b) => b.id === active) || null;
 
       await loadAppliancesForBrigade(active);
-      await loadReportsForBrigade(active);
+      await loadReportsForBrigade(active, activeBrigade);
 
       select.addEventListener("change", async (e) => {
         const brigadeId = e.target.value;
         if (!brigadeId) return;
         localStorage.setItem("activeBrigadeId", brigadeId);
+        activeBrigade = brigades.find((b) => b.id === brigadeId) || null;
         await loadAppliancesForBrigade(brigadeId);
-        await loadReportsForBrigade(brigadeId);
+        await loadReportsForBrigade(brigadeId, activeBrigade);
       });
     } catch (err) {
       console.error("Failed to load brigades:", err);


### PR DESCRIPTION
## Summary
- add authenticated single-report PDF download and admin/gear-manager report deletion endpoints
- add report row and report detail action sheets with Download report and role-gated Delete report
- delete report sign-off metadata and referenced note images when a report is deleted

## Validation
- node --check public/js/app-shell/screens/reports.js
- node --check public/js/app-shell/screens/report.js
- node --check public/js/app-shell/app-shell.js
- node --check functions/index.js
- npm test (functions)
- emulator smoke check: protected /app.html#/reports redirects to sign-in when unauthenticated

## Notes
- intentionally staged only the report-action files; unrelated local changes remain unstaged