### PR TITLE
[codex] Deploy functions before hosting

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -32,9 +32,6 @@ jobs:
           mkdir -p extensions
           echo "${{ secrets.FIRESTORE_SEND_EMAIL_ENV }}" > extensions/firestore-send-email.env
 
-      - name: Deploy Firebase (hosting, rules, indexes)
-        run: firebase deploy --project flashoverapplication --non-interactive --except functions
-
       - name: Deploy Firebase Functions (with retry)
         run: |
           for attempt in 1 2 3; do
@@ -42,3 +39,6 @@ jobs:
             firebase deploy --project flashoverapplication --non-interactive --only functions && break
             [ $attempt -lt 3 ] && sleep 20
           done
+
+      - name: Deploy Firebase (hosting, rules, indexes)
+        run: firebase deploy --project flashoverapplication --non-interactive --except functions


### PR DESCRIPTION
## Summary
- reorder the master Firebase deploy so Cloud Functions deploy before Hosting
- avoids exposing frontend code that calls new API routes before the API function has finished updating

## Context
The report delete UI was live before the updated `api` function finished deploying. During that deploy gap, DELETE requests could hit the old API and return a bare 404.

## Validation
- inspected the #68 merge workflow logs: Hosting completed before `functions[api]`
- workflow-only change; no app code changed